### PR TITLE
Add meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,12 @@
+project('ttf-parser', 'rust')
+
+add_project_arguments(['--edition=2018'], language: 'rust')
+
+ttf_parser = static_library('ttf_parser_capi', 'c-api/lib.rs', rust_crate_type: 'staticlib',
+  link_with: static_library('ttf_parser', 'src/lib.rs'),
+)
+
+ttf_parser_dep = declare_dependency(
+  link_with: ttf_parser,
+  include_directories: 'c-api/',
+)


### PR DESCRIPTION
This enables me to use ttf-parser as a meson subproject for https://github.com/harfbuzz/harfbuzz/pull/2510 use, not sure if is the best approach, I used my fork for that for now.