### PR TITLE
Extract more metrics from Post and OS/2 table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- `Face::is_monospaced`
+- `Face::italic_angle`
+- `Face::typo_ascender`
+- `Face::typo_descender`
+- `Face::typo_line_gap`
+- `Face::captial_height`
 
 ## [0.8.0] - 2020-07-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - `Face::is_monospaced`
 - `Face::italic_angle`
-- `Face::typo_ascender`
-- `Face::typo_descender`
-- `Face::typo_line_gap`
+- `Face::typographic_ascender`
+- `Face::typographic_descender`
+- `Face::typographic_line_gap`
 - `Face::captial_height`
 
 ## [0.8.0] - 2020-07-21

--- a/c-api/lib.rs
+++ b/c-api/lib.rs
@@ -367,8 +367,8 @@ pub extern "C" fn ttfp_get_line_gap(face: *const ttfp_face) -> i16 {
 ///
 /// @return `0` when OS/2 table is not present.
 #[no_mangle]
-pub extern "C" fn ttfp_get_typo_ascender(face: *const ttfp_face) -> i16 {
-    face_from_ptr(face).typo_ascender().unwrap_or(0)
+pub extern "C" fn ttfp_get_typographic_ascender(face: *const ttfp_face) -> i16 {
+    face_from_ptr(face).typographic_ascender().unwrap_or(0)
 }
 
 /// @brief Returns a horizontal typographic face descender.
@@ -380,8 +380,8 @@ pub extern "C" fn ttfp_get_typo_ascender(face: *const ttfp_face) -> i16 {
 ///
 /// @return `0` when OS/2 table is not present.
 #[no_mangle]
-pub extern "C" fn ttfp_get_typo_descender(face: *const ttfp_face) -> i16 {
-    face_from_ptr(face).typo_descender().unwrap_or(0)
+pub extern "C" fn ttfp_get_typographic_descender(face: *const ttfp_face) -> i16 {
+    face_from_ptr(face).typographic_descender().unwrap_or(0)
 }
 
 /// @brief Returns a horizontal typographic face line gap.
@@ -393,8 +393,8 @@ pub extern "C" fn ttfp_get_typo_descender(face: *const ttfp_face) -> i16 {
 ///
 /// @return `0` when OS/2 table is not present.
 #[no_mangle]
-pub extern "C" fn ttfp_get_typo_line_gap(face: *const ttfp_face) -> i16 {
-    face_from_ptr(face).typo_line_gap().unwrap_or(0)
+pub extern "C" fn ttfp_get_typographic_line_gap(face: *const ttfp_face) -> i16 {
+    face_from_ptr(face).typographic_line_gap().unwrap_or(0)
 }
 
 /// @brief Returns a vertical face ascender.

--- a/c-api/lib.rs
+++ b/c-api/lib.rs
@@ -285,6 +285,14 @@ pub extern "C" fn ttfp_is_oblique(face: *const ttfp_face) -> bool {
     face_from_ptr(face).is_oblique()
 }
 
+/// @brief Checks that face is marked as *Monospaced*.
+///
+/// @return `false` when `post` table is not present.
+#[no_mangle]
+pub extern "C" fn ttfp_is_monospaced(face: *const ttfp_face) -> bool {
+    face_from_ptr(face).is_monospaced()
+}
+
 /// @brief Checks that face is variable.
 ///
 /// Simply checks the presence of a `fvar` table.
@@ -308,6 +316,14 @@ pub extern "C" fn ttfp_get_weight(face: *const ttfp_face) -> u16 {
 #[no_mangle]
 pub extern "C" fn ttfp_get_width(face: *const ttfp_face) -> u16 {
     face_from_ptr(face).width().to_number()
+}
+
+/// @brief Returns face's italic angle.
+///
+/// @return Face's italic angle or `0.0` when `post` table is not present.
+#[no_mangle]
+pub extern "C" fn ttfp_get_italic_angle(face: *const ttfp_face) -> f32 {
+    face_from_ptr(face).italic_angle().unwrap_or(0.0)
 }
 
 /// @brief Returns a horizontal face ascender.
@@ -340,6 +356,45 @@ pub extern "C" fn ttfp_get_height(face: *const ttfp_face) -> i16 {
 #[no_mangle]
 pub extern "C" fn ttfp_get_line_gap(face: *const ttfp_face) -> i16 {
     face_from_ptr(face).line_gap()
+}
+
+/// @brief Returns a horizontal typographic face ascender.
+///
+/// Prefer `ttfp_get_ascender` unless you explicitly want this. This is a more
+/// low-level alternative.
+///
+/// This function is affected by variation axes.
+///
+/// @return `0` when OS/2 table is not present.
+#[no_mangle]
+pub extern "C" fn ttfp_get_typo_ascender(face: *const ttfp_face) -> i16 {
+    face_from_ptr(face).typo_ascender().unwrap_or(0)
+}
+
+/// @brief Returns a horizontal typographic face descender.
+///
+/// Prefer `ttfp_get_descender` unless you explicitly want this. This is a more
+/// low-level alternative.
+///
+/// This function is affected by variation axes.
+///
+/// @return `0` when OS/2 table is not present.
+#[no_mangle]
+pub extern "C" fn ttfp_get_typo_descender(face: *const ttfp_face) -> i16 {
+    face_from_ptr(face).typo_descender().unwrap_or(0)
+}
+
+/// @brief Returns a horizontal typographic face line gap.
+///
+/// Prefer `ttfp_get_line_gap` unless you explicitly want this. This is a more
+/// low-level alternative.
+///
+/// This function is affected by variation axes.
+///
+/// @return `0` when OS/2 table is not present.
+#[no_mangle]
+pub extern "C" fn ttfp_get_typo_line_gap(face: *const ttfp_face) -> i16 {
+    face_from_ptr(face).typo_line_gap().unwrap_or(0)
 }
 
 /// @brief Returns a vertical face ascender.
@@ -398,6 +453,16 @@ pub extern "C" fn ttfp_get_units_per_em(face: *const ttfp_face) -> u16 {
 #[no_mangle]
 pub extern "C" fn ttfp_get_x_height(face: *const ttfp_face) -> i16 {
     face_from_ptr(face).x_height().unwrap_or(0)
+}
+
+/// @brief Returns face's capital height.
+///
+/// This function is affected by variation axes.
+///
+/// @return capital height or 0 when OS/2 table is not present or when its version is < 2.
+#[no_mangle]
+pub extern "C" fn ttfp_get_capital_height(face: *const ttfp_face) -> i16 {
+    face_from_ptr(face).capital_height().unwrap_or(0)
 }
 
 /// @brief Returns face's underline metrics.

--- a/c-api/ttfparser.h
+++ b/c-api/ttfparser.h
@@ -292,6 +292,13 @@ bool ttfp_is_bold(const ttfp_face *face);
 bool ttfp_is_oblique(const ttfp_face *face);
 
 /**
+ * @brief Checks that face is marked as *Monospaced*.
+ *
+ * @return `false` when `post` table is not present.
+ */
+bool ttfp_is_monospaced(const ttfp_face *face);
+
+/**
  * @brief Checks that face is variable.
  *
  * Simply checks the presence of a `fvar` table.
@@ -312,6 +319,13 @@ uint16_t ttfp_get_weight(const ttfp_face *face);
  *         or when value is invalid.
  */
 uint16_t ttfp_get_width(const ttfp_face *face);
+
+/**
+ * @brief Returns face's italic angle.
+ *
+ * @return Face's italic angle or `0.0` when `post` table is not present.
+ */
+float ttfp_get_italic_angle(const ttfp_face *face);
 
 /**
  * @brief Returns a horizontal face ascender.
@@ -340,6 +354,42 @@ int16_t ttfp_get_height(const ttfp_face *face);
  * This function is affected by variation axes.
  */
 int16_t ttfp_get_line_gap(const ttfp_face *face);
+
+/**
+ * @brief Returns a horizontal typographic face ascender.
+ *
+ * Prefer `ttfp_get_ascender` unless you explicitly want this. This is a more
+ * low-level alternative.
+ *
+ * This function is affected by variation axes.
+ *
+ * @return `0` when OS/2 table is not present.
+ */
+int16_t ttfp_get_typographic_ascender(const ttfp_face *face);
+
+/**
+ * @brief Returns a horizontal typographic face ascender.
+ *
+ * Prefer `ttfp_get_descender` unless you explicitly want this. This is a more
+ * low-level alternative.
+ *
+ * This function is affected by variation axes.
+ *
+ * @return `0` when OS/2 table is not present.
+ */
+int16_t ttfp_get_typographic_descender(const ttfp_face *face);
+
+/**
+ * @brief Returns a horizontal typographic face line gap.
+ *
+ * Prefer `ttfp_get_line_gap` unless you explicitly want this. This is a more
+ * low-level alternative.
+ *
+ * This function is affected by variation axes.
+ *
+ * @return `0` when OS/2 table is not present.
+ */
+int16_t ttfp_get_typographic_line_gap(const ttfp_face *face);
 
 /**
  * @brief Returns a vertical face ascender.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -894,10 +894,10 @@ impl<'a> Face<'a> {
 
     /// Returns face's italic angle.
     ///
-    /// Returns `0.0` when `post` table is not present.
+    /// Returns `None` when `post` table is not present.
     #[inline]
-    pub fn italic_angle(&self) -> f32 {
-        try_opt_or!(self.post, 0.0).italic_angle()
+    pub fn italic_angle(&self) -> Option<f32> {
+        self.post.map(|table| table.italic_angle())
     }
 
     #[inline]
@@ -952,7 +952,10 @@ impl<'a> Face<'a> {
         }
     }
 
-    /// Returns a horizontal typo face ascender.
+    /// Returns a horizontal typographic face ascender.
+    ///
+    /// Prefer `Face::ascender` unless you explicitly want this. This is a more
+    /// low-level alternative.
     ///
     /// This method is affected by variation axes.
     ///
@@ -965,7 +968,10 @@ impl<'a> Face<'a> {
         })
     }
 
-    /// Returns a horizontal typo face descender.
+    /// Returns a horizontal typographic face descender.
+    ///
+    /// Prefer `Face::descender` unless you explicitly want this. This is a more
+    /// low-level alternative.
     ///
     /// This method is affected by variation axes.
     ///
@@ -978,7 +984,10 @@ impl<'a> Face<'a> {
         })
     }
 
-    /// Returns a horizontal typo face line gap.
+    /// Returns a horizontal typographic face line gap.
+    ///
+    /// Prefer `Face::line_gap` unless you explicitly want this. This is a more
+    /// low-level alternative.
     ///
     /// This method is affected by variation axes.
     ///
@@ -1047,13 +1056,13 @@ impl<'a> Face<'a> {
             .map(|v| self.apply_metrics_variation(Tag::from_bytes(b"xhgt"), v))
     }
 
-    /// Returns face's cap height.
+    /// Returns face's capital height.
     ///
     /// This method is affected by variation axes.
     ///
     /// Returns `None` when OS/2 table is not present or when its version is < 2.
     #[inline]
-    pub fn cap_height(&self) -> Option<i16> {
+    pub fn capital_height(&self) -> Option<i16> {
         self.os_2.and_then(|os_2| os_2.cap_height())
             .map(|v| self.apply_metrics_variation(Tag::from_bytes(b"cpht"), v))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -936,6 +936,45 @@ impl<'a> Face<'a> {
         }
     }
 
+    /// Returns a horizontal typo face ascender.
+    ///
+    /// This method is affected by variation axes.
+    ///
+    /// Returns `None` when OS/2 table is not present.
+    #[inline]
+    pub fn typo_ascender(&self) -> Option<i16> {
+        self.os_2.map(|table| {
+            let v = table.typo_ascender();
+            self.apply_metrics_variation(Tag::from_bytes(b"hasc"), v)
+        })
+    }
+
+    /// Returns a horizontal typo face descender.
+    ///
+    /// This method is affected by variation axes.
+    ///
+    /// Returns `None` when OS/2 table is not present.
+    #[inline]
+    pub fn typo_descender(&self) -> Option<i16> {
+        self.os_2.map(|table| {
+            let v = table.typo_descender();
+            self.apply_metrics_variation(Tag::from_bytes(b"hdsc"), v)
+        })
+    }
+
+    /// Returns a horizontal typo face line gap.
+    ///
+    /// This method is affected by variation axes.
+    ///
+    /// Returns `None` when OS/2 table is not present.
+    #[inline]
+    pub fn typo_line_gap(&self) -> Option<i16> {
+        self.os_2.map(|table| {
+            let v = table.typo_line_gap();
+            self.apply_metrics_variation(Tag::from_bytes(b"hlgp"), v)
+        })
+    }
+
     // TODO: does this affected by USE_TYPO_METRICS?
 
     /// Returns a vertical face ascender.
@@ -990,6 +1029,17 @@ impl<'a> Face<'a> {
     pub fn x_height(&self) -> Option<i16> {
         self.os_2.and_then(|os_2| os_2.x_height())
             .map(|v| self.apply_metrics_variation(Tag::from_bytes(b"xhgt"), v))
+    }
+
+    /// Returns face's cap height.
+    ///
+    /// This method is affected by variation axes.
+    ///
+    /// Returns `None` when OS/2 table is not present or when its version is < 2.
+    #[inline]
+    pub fn cap_height(&self) -> Option<i16> {
+        self.os_2.and_then(|os_2| os_2.cap_height())
+            .map(|v| self.apply_metrics_variation(Tag::from_bytes(b"cpht"), v))
     }
 
     /// Returns face's underline metrics.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -961,7 +961,7 @@ impl<'a> Face<'a> {
     ///
     /// Returns `None` when OS/2 table is not present.
     #[inline]
-    pub fn typo_ascender(&self) -> Option<i16> {
+    pub fn typographic_ascender(&self) -> Option<i16> {
         self.os_2.map(|table| {
             let v = table.typo_ascender();
             self.apply_metrics_variation(Tag::from_bytes(b"hasc"), v)
@@ -977,7 +977,7 @@ impl<'a> Face<'a> {
     ///
     /// Returns `None` when OS/2 table is not present.
     #[inline]
-    pub fn typo_descender(&self) -> Option<i16> {
+    pub fn typographic_descender(&self) -> Option<i16> {
         self.os_2.map(|table| {
             let v = table.typo_descender();
             self.apply_metrics_variation(Tag::from_bytes(b"hdsc"), v)
@@ -993,7 +993,7 @@ impl<'a> Face<'a> {
     ///
     /// Returns `None` when OS/2 table is not present.
     #[inline]
-    pub fn typo_line_gap(&self) -> Option<i16> {
+    pub fn typographic_line_gap(&self) -> Option<i16> {
         self.os_2.map(|table| {
             let v = table.typo_line_gap();
             self.apply_metrics_variation(Tag::from_bytes(b"hlgp"), v)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -859,6 +859,14 @@ impl<'a> Face<'a> {
         try_opt_or!(self.os_2, false).is_oblique()
     }
 
+    /// Checks that face is marked as *Monospaced*.
+    ///
+    /// Returns `false` when `post` table is not present.
+    #[inline]
+    pub fn is_monospaced(&self) -> bool {
+        try_opt_or!(self.post, false).is_monospaced()
+    }
+
     /// Checks that face is variable.
     ///
     /// Simply checks the presence of a `fvar` table.
@@ -882,6 +890,14 @@ impl<'a> Face<'a> {
     #[inline]
     pub fn width(&self) -> Width {
         try_opt_or!(self.os_2, Width::default()).width()
+    }
+
+    /// Returns face's italic angle.
+    ///
+    /// Returns `0.0` when `post` table is not present.
+    #[inline]
+    pub fn italic_angle(&self) -> f32 {
+        try_opt_or!(self.post, 0.0).italic_angle()
     }
 
     #[inline]

--- a/src/tables/os2.rs
+++ b/src/tables/os2.rs
@@ -15,6 +15,7 @@ const S_TYPO_ASCENDER_OFFSET: usize = 68;
 const S_TYPO_DESCENDER_OFFSET: usize = 70;
 const S_TYPO_LINE_GAP_OFFSET: usize = 72;
 const SX_HEIGHT_OFFSET: usize = 86;
+const S_CAP_HEIGHT_OFFSET: usize = 88;
 
 
 /// A font [weight](https://docs.microsoft.com/en-us/typography/opentype/spec/os2#usweightclass).
@@ -242,6 +243,15 @@ impl<'a> Table<'a> {
         } else {
             // We cannot use SafeStream here, because x height is an optional data.
             Stream::read_at::<i16>(self.data, SX_HEIGHT_OFFSET)
+        }
+    }
+
+    #[inline]
+    pub fn cap_height(&self) -> Option<i16> {
+        if self.version < 2 {
+            None
+        } else {
+            Stream::read_at::<i16>(self.data, S_CAP_HEIGHT_OFFSET)
         }
     }
 


### PR DESCRIPTION
This adds functions to extract a few more useful metrics:
- methods to get the font's `cap_height` and `italic_angle`
- an `is_monospaced` method (which fixes #17)
- three more methods to get the typo ascender, descender and line gap independently from `use_typo_metrics` (this would be useful to me because in one project I always want to use the typo metrics and not sometimes this or that depending on how the font is configured).

If you have any feedback, I'd be happy to incorporate it! I did not write any tests for this because I also didn't see tests for similarly simple table parsing stuff.