### PR TITLE
Codepoints (fixes #20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- `Subtable::codepoints`
 
 ## [0.8.1] - 2020-07-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- `Subtable::codepoints`
+- `cmap::Subtable::codepoints`
 
 ## [0.8.1] - 2020-07-29
 ### Added

--- a/src/tables/cmap/format0.rs
+++ b/src/tables/cmap/format0.rs
@@ -15,3 +15,44 @@ pub fn parse(data: &[u8], code_point: u32) -> Option<u16> {
         None
     }
 }
+
+pub fn codepoints(data: &[u8], mut f: impl FnMut(u32)) {
+    let mut s = Stream::new(data);
+    s.skip::<u16>(); // format
+    s.skip::<u16>(); // length
+    s.skip::<u16>(); // language
+
+    for code_point in 0..256 {
+        // In contrast to every other format, here we take a look at the glyph
+        // id and check whether it is zero because otherwise this method would
+        // always simply call `f` for `0..256` which would be kind of pointless
+        // (this array always has length 256 even when the face has only fewer
+        // glyphs).
+        let glyph_id: u8 = try_opt_or!(s.read(), ());
+        if glyph_id != 0 {
+            f(code_point);
+        }
+    }
+}
+
+#[cfg(test)]
+mod format0_tests {
+    use super::codepoints;
+
+    #[test]
+    fn maps_not_all_256_codepoints() {
+        let mut data = vec![
+            0x00, 0x00, // format: 0
+            0x01, 0x06, // subtable size: 262
+            0x00, 0x00, // language ID: 0
+        ];
+
+        // Map (only) codepoint 0x40 to 100.
+        data.extend(std::iter::repeat(0).take(256));
+        data[6 + 0x40] = 100;
+
+        let mut vec = vec![];
+        codepoints(&data, |c| vec.push(c));
+        assert_eq!(vec, [0x40]);
+    }
+}

--- a/src/tables/cmap/format0.rs
+++ b/src/tables/cmap/format0.rs
@@ -16,7 +16,7 @@ pub fn parse(data: &[u8], code_point: u32) -> Option<u16> {
     }
 }
 
-pub fn codepoints(data: &[u8], mut f: impl FnMut(u32)) {
+pub fn codepoints(data: &[u8], mut f: impl FnMut(u32)) -> Option<()> {
     let mut s = Stream::new(data);
     s.skip::<u16>(); // format
     s.skip::<u16>(); // length
@@ -28,11 +28,13 @@ pub fn codepoints(data: &[u8], mut f: impl FnMut(u32)) {
         // always simply call `f` for `0..256` which would be kind of pointless
         // (this array always has length 256 even when the face has only fewer
         // glyphs).
-        let glyph_id: u8 = try_opt_or!(s.read(), ());
+        let glyph_id: u8 = s.read()?;
         if glyph_id != 0 {
             f(code_point);
         }
     }
+
+    Some(())
 }
 
 #[cfg(test)]

--- a/src/tables/cmap/format0.rs
+++ b/src/tables/cmap/format0.rs
@@ -42,7 +42,7 @@ pub fn codepoints(data: &[u8], mut f: impl FnMut(u32)) -> Option<()> {
 }
 
 #[cfg(test)]
-mod format0_tests {
+mod tests {
     use super::{parse, codepoints};
 
     #[test]
@@ -60,7 +60,7 @@ mod format0_tests {
         assert_eq!(parse(&data, 0), None);
         assert_eq!(parse(&data, 0x40), Some(100));
         assert_eq!(parse(&data, 100), None);
-      
+
         let mut vec = vec![];
         codepoints(&data, |c| vec.push(c));
         assert_eq!(vec, [0x40]);

--- a/src/tables/cmap/format10.rs
+++ b/src/tables/cmap/format10.rs
@@ -16,17 +16,19 @@ pub fn parse(data: &[u8], code_point: u32) -> Option<u16> {
     glyphs.get(idx)
 }
 
-pub fn codepoints(data: &[u8], mut f: impl FnMut(u32)) {
+pub fn codepoints(data: &[u8], mut f: impl FnMut(u32)) -> Option<()> {
     let mut s = Stream::new(data);
     s.skip::<u16>(); // format
     s.skip::<u16>(); // reserved
     s.skip::<u32>(); // length
     s.skip::<u32>(); // language
-    let first_code_point: u32 = try_opt_or!(s.read(), ());
-    let count: u32 = try_opt_or!(s.read(), ());
+    let first_code_point: u32 = s.read()?;
+    let count: u32 = s.read()?;
 
     for i in 0..count {
-        let code_point = try_opt_or!(first_code_point.checked_add(i), ());
+        let code_point = first_code_point.checked_add(i)?;
         f(code_point);
     }
+
+    Some(())
 }

--- a/src/tables/cmap/format10.rs
+++ b/src/tables/cmap/format10.rs
@@ -15,3 +15,18 @@ pub fn parse(data: &[u8], code_point: u32) -> Option<u16> {
     let idx = code_point.checked_sub(first_code_point)?;
     glyphs.get(idx)
 }
+
+pub fn codepoints(data: &[u8], mut f: impl FnMut(u32)) {
+    let mut s = Stream::new(data);
+    s.skip::<u16>(); // format
+    s.skip::<u16>(); // reserved
+    s.skip::<u32>(); // length
+    s.skip::<u32>(); // language
+    let first_code_point: u32 = try_opt_or!(s.read(), ());
+    let count: u32 = try_opt_or!(s.read(), ());
+
+    for i in 0..count {
+        let code_point = try_opt_or!(first_code_point.checked_add(i), ());
+        f(code_point);
+    }
+}

--- a/src/tables/cmap/format12.rs
+++ b/src/tables/cmap/format12.rs
@@ -43,3 +43,18 @@ pub fn parse(data: &[u8], code_point: u32) -> Option<u16> {
 
     None
 }
+
+pub fn codepoints(data: &[u8], mut f: impl FnMut(u32)) {
+    let mut s = Stream::new(data);
+    s.skip::<u16>(); // format
+    s.skip::<u16>(); // reserved
+    s.skip::<u32>(); // length
+    s.skip::<u32>(); // language
+    let count: u32 = try_opt_or!(s.read(), ());
+    let groups = try_opt_or!(s.read_array32::<SequentialMapGroup>(count), ());
+    for group in groups {
+        for code_point in group.start_char_code..=group.end_char_code {
+            f(code_point);
+        }
+    }
+}

--- a/src/tables/cmap/format12.rs
+++ b/src/tables/cmap/format12.rs
@@ -44,17 +44,19 @@ pub fn parse(data: &[u8], code_point: u32) -> Option<u16> {
     None
 }
 
-pub fn codepoints(data: &[u8], mut f: impl FnMut(u32)) {
+pub fn codepoints(data: &[u8], mut f: impl FnMut(u32)) -> Option<()> {
     let mut s = Stream::new(data);
     s.skip::<u16>(); // format
     s.skip::<u16>(); // reserved
     s.skip::<u32>(); // length
     s.skip::<u32>(); // language
-    let count: u32 = try_opt_or!(s.read(), ());
-    let groups = try_opt_or!(s.read_array32::<SequentialMapGroup>(count), ());
+    let count: u32 = s.read()?;
+    let groups = s.read_array32::<SequentialMapGroup>(count)?;
     for group in groups {
         for code_point in group.start_char_code..=group.end_char_code {
             f(code_point);
         }
     }
+
+    Some(())
 }

--- a/src/tables/cmap/format13.rs
+++ b/src/tables/cmap/format13.rs
@@ -22,7 +22,7 @@ pub fn parse(data: &[u8], code_point: u32) -> Option<u16> {
     None
 }
 
-pub fn codepoints(data: &[u8], f: impl FnMut(u32)) {
+pub fn codepoints(data: &[u8], f: impl FnMut(u32)) -> Option<()> {
     // Only the glyph id mapping differs for this table. The code points are the
     // same as for format 12.
     super::format12::codepoints(data, f)

--- a/src/tables/cmap/format13.rs
+++ b/src/tables/cmap/format13.rs
@@ -21,3 +21,9 @@ pub fn parse(data: &[u8], code_point: u32) -> Option<u16> {
 
     None
 }
+
+pub fn codepoints(data: &[u8], f: impl FnMut(u32)) {
+    // Only the glyph id mapping differs for this table. The code points are the
+    // same as for format 12.
+    super::format12::codepoints(data, f)
+}

--- a/src/tables/cmap/format2.rs
+++ b/src/tables/cmap/format2.rs
@@ -128,7 +128,7 @@ pub fn codepoints(data: &[u8], mut f: impl FnMut(u32)) -> Option<()> {
 }
 
 #[cfg(test)]
-mod format2_tests {
+mod tests {
     use crate::parser::FromData;
     use super::{parse, codepoints};
 
@@ -163,7 +163,7 @@ mod format2_tests {
         codepoints(&data, |c| vec.push(c));
         assert_eq!(vec, [10256, 10257, 10258, 254, 255]);
     }
-    
+
     #[test]
     fn codepoint_at_range_end() {
         let mut data = vec![

--- a/src/tables/cmap/format2.rs
+++ b/src/tables/cmap/format2.rs
@@ -91,3 +91,80 @@ pub fn parse(data: &[u8], code_point: u32) -> Option<u16> {
 
     u16::try_from((i32::from(glyph) + i32::from(sub_header.id_delta)) % 65536).ok()
 }
+
+pub fn codepoints(data: &[u8], mut f: impl FnMut(u32)) {
+    let mut s = Stream::new(data);
+    s.skip::<u16>(); // format
+    s.skip::<u16>(); // length
+    s.skip::<u16>(); // language
+    let sub_header_keys = try_opt_or!(s.read_array16::<u16>(256), ());
+
+    // The maximum index in a sub_header_keys is a sub_headers count.
+    let sub_headers_count =
+        try_opt_or!(sub_header_keys.into_iter().map(|n| n / 8).max(), ()) + 1;
+
+    let sub_headers =
+        try_opt_or!(s.read_array16::<SubHeaderRecord>(sub_headers_count), ());
+
+    for first_byte in 0u16..256 {
+        let i = try_opt_or!(sub_header_keys.get(first_byte), ()) / 8;
+        let sub_header = try_opt_or!(sub_headers.get(i), ());
+        let first_code = sub_header.first_code;
+
+        if i == 0 {
+            // This is a single byte code.
+            let range_end = try_opt_or!(
+                first_code.checked_add(sub_header.entry_count), ()
+            );
+
+            if first_byte >= first_code && first_byte < range_end {
+                f(u32::from(first_byte));
+            }
+        } else {
+            // This is a two byte code.
+            let base = try_opt_or!(first_code.checked_add(first_byte << 8), ());
+            for k in 0..sub_header.entry_count {
+                let code_point = try_opt_or!(base.checked_add(k), ());
+                f(u32::from(code_point));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod format2_tests {
+    use crate::parser::FromData;
+    use super::codepoints;
+
+    #[test]
+    fn collect_codepoints() {
+        let mut data = vec![
+            0x00, 0x02, // format: 2
+            0x02, 0x16, // subtable size: 534
+            0x00, 0x00, // language ID: 0
+        ];
+
+        // Make only high byte 0x28 multi-byte.
+        data.extend(std::iter::repeat(0x00).take(256 * u16::SIZE));
+        data[6 + 0x28 * u16::SIZE + 1] = 0x08;
+
+        data.extend(&[
+            // First sub header (for single byte mapping)
+            0x00, 0xFE, // first code: 254
+            0x00, 0x02, // entry count: 2
+            0x00, 0x00, // id delta: uninteresting
+            0x00, 0x00, // id range offset: uninteresting
+            // Second sub header (for high byte 0x28)
+            0x00, 0x10, // first code: (0x28 << 8) + 0x10 = 10256,
+            0x00, 0x03, // entry count: 3
+            0x00, 0x00, // id delta: uninteresting
+            0x00, 0x00, // id range offset: uninteresting
+        ]);
+
+        // Now only glyph ID's would follow. Not interesting for codepoints.
+
+        let mut vec = vec![];
+        codepoints(&data, |c| vec.push(c));
+        assert_eq!(vec, [10256, 10257, 10258, 254, 255]);
+    }
+}

--- a/src/tables/cmap/format4.rs
+++ b/src/tables/cmap/format4.rs
@@ -66,9 +66,31 @@ pub fn parse(data: &[u8], code_point: u32) -> Option<u16> {
     None
 }
 
+pub fn codepoints(data: &[u8], mut f: impl FnMut(u32)) {
+    let mut s = Stream::new(data);
+    s.advance(6); // format + length + language
+    let seg_count_x2: u16 = try_opt_or!(s.read(), ());
+    if seg_count_x2 < 2 {
+        return;
+    }
+
+    let seg_count = seg_count_x2 / 2;
+    s.advance(6); // searchRange + entrySelector + rangeShift
+
+    let end_codes = try_opt_or!(s.read_array16::<u16>(seg_count), ());
+    s.skip::<u16>(); // reservedPad
+    let start_codes = try_opt_or!(s.read_array16::<u16>(seg_count), ());
+
+    for (start, end) in start_codes.into_iter().zip(end_codes) {
+        for code_point in start..=end {
+            f(u32::from(code_point));
+        }
+    }
+}
+
 #[cfg(test)]
 mod format4_tests {
-    use super::parse;
+    use super::{parse, codepoints};
 
     #[test]
     fn single_glyph() {
@@ -456,5 +478,30 @@ mod format4_tests {
         ];
 
         assert_eq!(parse(data, 0x41), None);
+    }
+
+    #[test]
+    fn collect_codepoints() {
+        let data = &[
+            0x00, 0x04, // format: 4
+            0x00, 0x18, // subtable size: 24
+            0x00, 0x00, // language ID: 0
+            0x00, 0x04, // 2 x segCount: 4
+            0x00, 0x02, // search range: 2
+            0x00, 0x00, // entry selector: 0
+            0x00, 0x02, // range shift: 2
+            // End character codes
+            0x00, 0x22, // char code [0]: 34
+            0xFF, 0xFF, // char code [1]: 65535
+            0x00, 0x00, // reserved: 0
+            // Start character codes
+            0x00, 0x1B, // char code [0]: 27
+            0xFF, 0xFD, // char code [1]: 65533
+            // codepoints does not care about glyph ids
+        ];
+
+        let mut vec = vec![];
+        codepoints(data, |c| vec.push(c));
+        assert_eq!(vec, [27, 28, 29, 30, 31, 32, 33, 34, 65533, 65534, 65535]);
     }
 }

--- a/src/tables/cmap/format4.rs
+++ b/src/tables/cmap/format4.rs
@@ -91,7 +91,7 @@ pub fn codepoints(data: &[u8], mut f: impl FnMut(u32)) -> Option<()> {
 }
 
 #[cfg(test)]
-mod format4_tests {
+mod tests {
     use super::{parse, codepoints};
 
     #[test]

--- a/src/tables/cmap/format6.rs
+++ b/src/tables/cmap/format6.rs
@@ -20,16 +20,18 @@ pub fn parse(data: &[u8], code_point: u32) -> Option<u16> {
     glyphs.get(idx)
 }
 
-pub fn codepoints(data: &[u8], mut f: impl FnMut(u32)) {
+pub fn codepoints(data: &[u8], mut f: impl FnMut(u32)) -> Option<()> {
     let mut s = Stream::new(data);
     s.skip::<u16>(); // format
     s.skip::<u16>(); // length
     s.skip::<u16>(); // language
-    let first_code_point: u16 = try_opt_or!(s.read(), ());
-    let count: u16 = try_opt_or!(s.read(), ());
+    let first_code_point: u16 = s.read()?;
+    let count: u16 = s.read()?;
 
     for i in 0..count {
-        let code_point = try_opt_or!(first_code_point.checked_add(i), ());
+        let code_point = first_code_point.checked_add(i)?;
         f(u32::from(code_point));
     }
+
+    Some(())
 }

--- a/src/tables/cmap/format6.rs
+++ b/src/tables/cmap/format6.rs
@@ -19,3 +19,17 @@ pub fn parse(data: &[u8], code_point: u32) -> Option<u16> {
     let idx = code_point.checked_sub(first_code_point)?;
     glyphs.get(idx)
 }
+
+pub fn codepoints(data: &[u8], mut f: impl FnMut(u32)) {
+    let mut s = Stream::new(data);
+    s.skip::<u16>(); // format
+    s.skip::<u16>(); // length
+    s.skip::<u16>(); // language
+    let first_code_point: u16 = try_opt_or!(s.read(), ());
+    let count: u16 = try_opt_or!(s.read(), ());
+
+    for i in 0..count {
+        let code_point = try_opt_or!(first_code_point.checked_add(i), ());
+        f(u32::from(code_point));
+    }
+}

--- a/src/tables/cmap/mod.rs
+++ b/src/tables/cmap/mod.rs
@@ -194,39 +194,38 @@ impl<'a> Subtable<'a> {
     /// Returns without doing anything:
     /// - when format is `MixedCoverage`, since it's not supported.
     /// - when format is `UnicodeVariationSequences`, since it's not supported.
-    pub fn codepoints<F>(&self, f: F)
-    where
-        F: FnMut(u32),
-    {
-        match self.format {
+    pub fn codepoints<F: FnMut(u32)>(&self, f: F) {
+        let _ = match self.format {
             Format::ByteEncodingTable => {
-                format0::codepoints(self.subtable_data, f);
+                format0::codepoints(self.subtable_data, f)
             }
             Format::HighByteMappingThroughTable => {
-                format2::codepoints(self.subtable_data, f);
+                format2::codepoints(self.subtable_data, f)
             },
             Format::SegmentMappingToDeltaValues => {
-                format4::codepoints(self.subtable_data, f);
+                format4::codepoints(self.subtable_data, f)
             },
             Format::TrimmedTableMapping => {
-                format6::codepoints(self.subtable_data, f);
+                format6::codepoints(self.subtable_data, f)
             },
             Format::MixedCoverage => {
                 // Unsupported
+                None
             },
             Format::TrimmedArray => {
-                format10::codepoints(self.subtable_data, f);
+                format10::codepoints(self.subtable_data, f)
             },
             Format::SegmentedCoverage => {
-                format12::codepoints(self.subtable_data, f);
+                format12::codepoints(self.subtable_data, f)
             }
             Format::ManyToOneRangeMappings => {
-                format13::codepoints(self.subtable_data, f);
+                format13::codepoints(self.subtable_data, f)
             },
             Format::UnicodeVariationSequences => {
                 // Unsupported
+                None
             },
-        }
+        };
     }
 }
 

--- a/src/tables/cmap/mod.rs
+++ b/src/tables/cmap/mod.rs
@@ -122,7 +122,7 @@ impl<'a> Subtable<'a> {
 
     /// Maps a character to a glyph ID.
     ///
-    /// This is a low-level method and unlike `Face::glyph_index` is doesn't
+    /// This is a low-level method and unlike `Face::glyph_index` it doesn't
     /// check that the current encoding is Unicode.
     /// It simply maps a `u32` codepoint number to a glyph ID.
     ///
@@ -178,6 +178,54 @@ impl<'a> Subtable<'a> {
             format14::parse(self.subtable_data, u32::from(c), u32::from(variation))
         } else {
             None
+        }
+    }
+
+    /// Calls `f` for all codepoints contained in this subtable.
+    ///
+    /// This is a low-level method and it doesn't check that the current
+    /// encoding is Unicode. It simply calls the function `f` for all `u32`
+    /// codepoints that are present in this subtable.
+    ///
+    /// Note that this may list codepoints for which `glyph_index` still returns
+    /// `None` because this method finds all codepoints which were _defined_ in
+    /// this subtable. The subtable may still map them to glyph ID `0`.
+    ///
+    /// Returns without doing anything:
+    /// - when format is `MixedCoverage`, since it's not supported.
+    /// - when format is `UnicodeVariationSequences`, since it's not supported.
+    pub fn codepoints<F>(&self, f: F)
+    where
+        F: FnMut(u32),
+    {
+        match self.format {
+            Format::ByteEncodingTable => {
+                format0::codepoints(self.subtable_data, f);
+            }
+            Format::HighByteMappingThroughTable => {
+                format2::codepoints(self.subtable_data, f);
+            },
+            Format::SegmentMappingToDeltaValues => {
+                format4::codepoints(self.subtable_data, f);
+            },
+            Format::TrimmedTableMapping => {
+                format6::codepoints(self.subtable_data, f);
+            },
+            Format::MixedCoverage => {
+                // Unsupported
+            },
+            Format::TrimmedArray => {
+                format10::codepoints(self.subtable_data, f);
+            },
+            Format::SegmentedCoverage => {
+                format12::codepoints(self.subtable_data, f);
+            }
+            Format::ManyToOneRangeMappings => {
+                format13::codepoints(self.subtable_data, f);
+            },
+            Format::UnicodeVariationSequences => {
+                // Unsupported
+            },
         }
     }
 }


### PR DESCRIPTION
I implemented reading all codepoints from a subtable through `Subtable::codepoints` as laid out in #20.

As discussed, this only parses the codepoints and not the glyph indices. Normally, instead of returning glyph ID `0`, the parsing methods return `None`. Since the codepoint-methods don't know about the glyph indices, calling `glyph_index` on a collected codepoint may now still return `None`. But I think that isn't too bad since a user can still check whether `glyph_index` returns `None` for each collected codepoint if necessary.

There is one exception to this rule for format 0 because otherwise we would always return all codepoints from `0` to `255` even though some of them may definitely be unmapped (aka mapped to zero).

While implementing format 0 and format 2 I noticed two things which I believe are bugs. I took the liberty to fix them in this PR:
- For format 0, the parser would return glyph ID `0` instead of `None` even though (at least I think) zero means unmapped for this table (as it has fixed size and otherwise couldn't support fonts with less than 256 mappings)
- For format 2, there was a `>` comparison with an exclusive range end which should have been `>=` as far as I can tell. This could lead to a codepoint being mapped to a glyph when it was in fact unmapped.

I added tests for the two bugs and for the `codepoints` for formats 0 and the more complex ones 2 & 4.  