### PR TITLE
(cmap) Don't return glyph ID `0` instead of `None` for format 0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- (cmap) Incorrectly returning glyph ID `0` instead of `None` for format 0
 
 ## [0.8.1] - 2020-07-29
 ### Added

--- a/src/tables/cmap/format0.rs
+++ b/src/tables/cmap/format0.rs
@@ -5,13 +5,39 @@ use crate::parser::{Stream, NumFrom};
 pub fn parse(data: &[u8], code_point: u32) -> Option<u16> {
     let mut s = Stream::new(data);
     s.skip::<u16>(); // format
-    let length: u16 = s.read()?;
+    s.skip::<u16>(); // length
     s.skip::<u16>(); // language
 
-    if code_point < u32::from(length) {
-        s.advance(usize::num_from(code_point));
-        Some(u16::from(s.read::<u8>()?))
+    s.advance(usize::num_from(code_point));
+    let glyph_id: u8 = s.read()?;
+
+    // Make sure that the glyph is not zero, the array always has length 256,
+    // but some codepoints may be mapped to zero.
+    if glyph_id != 0 {
+        Some(u16::from(glyph_id))
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod format0_tests {
+    use super::parse;
+
+    #[test]
+    fn maps_not_all_256_codepoints() {
+        let mut data = vec![
+            0x00, 0x00, // format: 0
+            0x01, 0x06, // subtable size: 262
+            0x00, 0x00, // language ID: 0
+        ];
+
+        // Map (only) codepoint 0x40 to 100.
+        data.extend(std::iter::repeat(0).take(256));
+        data[6 + 0x40] = 100;
+
+        assert_eq!(parse(&data, 0), None);
+        assert_eq!(parse(&data, 0x40), Some(100));
+        assert_eq!(parse(&data, 100), None);
     }
 }


### PR DESCRIPTION
For format 0, the parser would return glyph ID 0 instead of None even though (at least I think) zero means unmapped for this table (as it has fixed size and otherwise couldn't support fonts with less than 256 mappings).