### PR TITLE
(cmap) Fix invalid mapping for format 2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- (cmap) Possible invalid glyph mapping for format 2
 
 ## [0.8.1] - 2020-07-29
 ### Added


### PR DESCRIPTION
For format 2, there was a `>` comparison with an exclusive range end which should have been `>=` as far as I can tell. This could lead to a codepoint being mapped to a glyph when it was in fact unmapped.