### PR TITLE
Fix edge case in seac_code_to_glyph_id and clarify behaviour

### DIFF
--- a/src/tables/cff/cff1.rs
+++ b/src/tables/cff/cff1.rs
@@ -685,8 +685,8 @@ fn seac_code_to_glyph_id(charset: &Charset, n: f32) -> Option<GlyphId> {
 
     match charset {
         Charset::ISOAdobe => {
-            // Not sure why code should be less than 228/zcaron, but this is what harfbuzz does.
-            if code < 228 { Some(GlyphId(sid.0)) } else { None }
+            // ISO Adobe charset only defines string ids up to 228 (zcaron)
+            if code <= 228 { Some(GlyphId(sid.0)) } else { None }
         }
         Charset::Expert | Charset::ExpertSubset => None,
         _ => charset.sid_to_gid(sid),


### PR DESCRIPTION
Saw the comment about 228/zcaron and set out to find an explanation. The reason is that the ISO Adobe charset only defines string ids up to 228 (p. 47 of [CFF Spec](https://wwwimages2.adobe.com/content/dam/acom/en/devnet/font/pdfs/5176.CFF.pdf)). Then the `<` stood out to me as it seems like 228 is valid too. Confirmed this by checking Harfbuzz:

https://github.com/harfbuzz/harfbuzz/blob/c8c5e52aba904cfede1c7e8e1043a392053938e6/src/hb-ot-cff1-table.hh#L1166