### PR TITLE
Exclude fonts from package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/RazrFalcon/ttf-parser"
 documentation = "https://docs.rs/ttf-parser/"
 readme = "README.md"
 edition = "2018"
-exclude = ["benches/**"]
+exclude = ["benches/**", "fonts/**"]
 
 [features]
 default = ["std", "variable-fonts"]


### PR DESCRIPTION
I'm using this crate in Fuchsia, where we vendor all third party crates. Our policy is to not host font files, so it would be great if you could accept this change that would prevent them from being in the package and thus vendored.