### PR TITLE
0.12.1: prepare extra derives

### DIFF
--- a/src/ggg.rs
+++ b/src/ggg.rs
@@ -65,7 +65,7 @@ impl<'a> CoverageTable<'a> {
 
 /// A value of [Class Definition Table](https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2#class-definition-table).
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Hash)]
 pub struct Class(pub u16);
 
 impl FromData for Class {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub use tables::{cmap, kern};
 
 /// A type-safe wrapper for glyph ID.
 #[repr(transparent)]
-#[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Default, Debug)]
+#[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Default, Debug, Hash)]
 pub struct GlyphId(pub u16);
 
 impl FromData for GlyphId {

--- a/src/tables/cmap/mod.rs
+++ b/src/tables/cmap/mod.rs
@@ -264,7 +264,7 @@ impl FromData for EncodingRecord {
 
 
 /// A character map encoding format.
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 #[allow(missing_docs)]
 pub enum Format {
     ByteEncodingTable = 0,

--- a/src/tables/gdef.rs
+++ b/src/tables/gdef.rs
@@ -9,7 +9,7 @@ use crate::ggg::{Class, ClassDefinitionTable, CoverageTable};
 
 
 /// A [glyph class](https://docs.microsoft.com/en-us/typography/opentype/spec/gdef#glyph-class-definition-table).
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 #[allow(missing_docs)]
 pub enum GlyphClass {
     Base      = 1,

--- a/src/tables/os2.rs
+++ b/src/tables/os2.rs
@@ -21,7 +21,7 @@ const CAP_HEIGHT_OFFSET: usize = 88;
 
 
 /// A font [weight](https://docs.microsoft.com/en-us/typography/opentype/spec/os2#usweightclass).
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Hash)]
 #[allow(missing_docs)]
 pub enum Weight {
     Thin,
@@ -82,7 +82,7 @@ impl Default for Weight {
 
 
 /// A font [width](https://docs.microsoft.com/en-us/typography/opentype/spec/os2#uswidthclass).
-#[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
 #[allow(missing_docs)]
 pub enum Width {
     UltraCondensed,
@@ -124,7 +124,7 @@ impl Default for Width {
 
 /// A script metrics used by subscript and superscript.
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Hash)]
 pub struct ScriptMetrics {
     /// Horizontal font size.
     pub x_size: i16,


### PR DESCRIPTION
This is more than what I require, but I think all make sense *unless* there is a chance they may have incompatible fields such as `f32` in the future.

Since the PR to `fontdb` will depend on this and it's non-breaking, I marked this as a release (didn't check whether anything else needs adding to the changelog).