### PR TITLE
Benchmark `glyph_index` when glyph is not found

### DIFF
--- a/benches/methods_perf.rs
+++ b/benches/methods_perf.rs
@@ -125,6 +125,14 @@ fn glyph_index_u41(bencher: &mut bencher::Bencher) {
     })
 }
 
+fn glyph_index_not_found(bencher: &mut bencher::Bencher) {
+    let font_data = std::fs::read("fonts/SourceSansPro-Regular.ttf").unwrap();
+    let face = ttf::Face::from_slice(&font_data, 0).unwrap();
+    bencher.iter(|| {
+        bencher::black_box(face.glyph_index('\u{f001}').is_none());
+    })
+}
+
 struct Builder(usize);
 
 impl ttf_parser::OutlineBuilder for Builder {
@@ -169,6 +177,7 @@ bencher::benchmark_group!(perf,
     glyph_name_cff_8,
     glyph_name_cff_276,
     family_name,
-    glyph_index_u41
+    glyph_index_u41,
+    glyph_index_not_found
 );
 bencher::benchmark_main!(perf);


### PR DESCRIPTION
Just because I think it's quite slow

Tested on AMD Ryzen 7 1700 + Arch linux 64-bit:
```
running 16 tests
test family_name                 ... bench:         271 ns/iter (+/- 29)
test from_data_otf_cff           ... bench:       1,267 ns/iter (+/- 245)
test from_data_otf_cff2          ... bench:       1,264 ns/iter (+/- 112)
test from_data_ttf               ... bench:         666 ns/iter (+/- 84)
test glyph_index_not_found       ... bench:       1,887 ns/iter (+/- 136)
test glyph_index_u41             ... bench:          24 ns/iter (+/- 1)
test glyph_name_cff_276          ... bench:          97 ns/iter (+/- 3)
test glyph_name_cff_8            ... bench:           8 ns/iter (+/- 0)
test glyph_name_post_276         ... bench:         286 ns/iter (+/- 21)
test glyph_name_post_8           ... bench:           3 ns/iter (+/- 1)
test outline_glyph_276_from_cff  ... bench:       1,365 ns/iter (+/- 43)
test outline_glyph_276_from_cff2 ... bench:       1,318 ns/iter (+/- 103)
test outline_glyph_276_from_glyf ... bench:       1,238 ns/iter (+/- 120)
test outline_glyph_8_from_cff    ... bench:         507 ns/iter (+/- 45)
test outline_glyph_8_from_cff2   ... bench:         783 ns/iter (+/- 75)
test outline_glyph_8_from_glyf   ... bench:         548 ns/iter (+/- 109)
```