### PR TITLE
Optimize Face::glyph_index

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1265,20 +1265,10 @@ impl<'a> Face<'a> {
     ///
     /// All subtable formats except Mixed Coverage (8) are supported.
     ///
-    /// If you need a more low-level control, prefer `Face::character_mapping_subtables`.
+    /// If you need a more low-level control, see `face.tables().cmap`.
     #[inline]
     pub fn glyph_index(&self, code_point: char) -> Option<GlyphId> {
-        for encoding in self.tables.cmap?.subtables {
-            if !encoding.is_unicode() {
-                continue;
-            }
-
-            if let Some(id) = encoding.glyph_index(code_point) {
-                return Some(id);
-            }
-        }
-
-        None
+        self.tables.cmap?.subtables.glyph_index(code_point)
     }
 
     /// Resolves a variation of a Glyph ID from two code points.


### PR DESCRIPTION
Add an optimised code path for `Face::glyph_index` that brings it's performance back to around how `0.12.x` did.

```
name             master ns/iter  change ns/iter  diff ns/iter   diff %  speedup 
glyph_index_u41  24              13                       -11  -45.83%   x 1.85 
```

Maybe with some further tweaking the code can retain more grace & performance.