### PR TITLE
Svg document records index fix(doc_list_offset was not considered)

### DIFF
--- a/src/tables/svg.rs
+++ b/src/tables/svg.rs
@@ -128,7 +128,7 @@ impl<'a> Table<'a> {
 
         Some(Table {
             documents: SvgDocumentsList {
-                data,
+                data: &data[doc_list_offset.0 as usize..],
                 records,
             }
         })


### PR DESCRIPTION
The SVG document record offset for a document is with respect to the beginning of the SVGDocumentList and not with respect to the table as mentioned here 
https://docs.microsoft.com/en-us/typography/opentype/spec/svg