### PR TITLE
docs: add COLR/CPAL table and update FreeType information

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ There are roughly three types of TrueType tables:
 | `bloc` table      |                        | ✓                   |                                |
 | `CBDT` table      | ✓                      | ✓                   |                                |
 | `CBLC` table      | ✓                      | ✓                   |                                |
+| `COLR` table      |                        | ✓ (2.10.0)          |                                |
+| `CPAL` table      |                        | ✓ (2.10.0)          |                                |
+| `COLR` table v1   |                        | ✓ (2.11.0)          |                                |
 | `CFF `&nbsp;table | ✓                      | ✓                   | ~ (no `seac` support)          |
 | `CFF2` table      | ✓                      | ✓                   |                                |
 | `cmap` table      | ~ (no 8)               | ✓                   | ~ (no 2,8,10,14; Unicode-only) |
@@ -90,7 +93,7 @@ There are roughly three types of TrueType tables:
 | `OS/2` table      | ✓                      | ✓                   |                                |
 | `post` table      | ✓                      | ✓                   |                                |
 | `sbix` table      | ~ (PNG only)           | ~ (PNG only)        |                                |
-| `SVG `&nbsp;table | ✓                      |                     | ✓                              |
+| `SVG `&nbsp;table | ✓                      | ✓ (2.12.0)          | ✓                              |
 | `trak` table      | ✓                      |                     |                                |
 | `vhea` table      | ✓                      | ✓                   |                                |
 | `vmtx` table      | ✓                      | ✓                   |                                |


### PR DESCRIPTION
- Add `COLR/CPAL` tables
- FreeType 2.10.0 support `COLR/CPAL` tables
- FreeType 2.11.0 support `COLR` table v1 ([COLRv1](https://caniuse.com/colr-v1))
- [FreeType 2.12.0](https://github.com/freetype/freetype/commit/21d0fa374200aecc6605daf034a47167ea82ed6f) support `SVG` table(OT-SVG)
  > FreeType now handles OT-SVG fonts, to be controlled with
FT_CONFIG_OPTION_SVG configuration macro. By default, it can
only load the 'SVG ' table of an OpenType font. However, by using
the svg-hooks property of the new 'ot-svg' module it is possible
to register an external SVG rendering engine. The FreeType demo
programs have been set up to use 'librsvg' as the rendering
library.