### PR TITLE
Fix `glyph_hor_side_bearing` to handle `None` `hvar.side_bearing_offset`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1450,9 +1450,14 @@ impl<'a> Face<'a> {
 
             if self.is_variable() {
                 // Ignore variation offset when `hvar` is not set.
-                if let Some(hvar) = self.tables.hvar {
+                if let Some(side_bearing_offset) = self
+                    .tables
+                    .hvar
+                    .as_ref()
+                    .and_then(|hvar| hvar.side_bearing_offset(glyph_id, self.coords()))
+                {
                     // We can't use `round()` in `no_std`, so this is the next best thing.
-                    bearing += hvar.side_bearing_offset(glyph_id, self.coords())? + 0.5;
+                    bearing += side_bearing_offset + 0.5;
                 }
             }
 


### PR DESCRIPTION
Handle the case `hvar.side_bearing_offset == None` without returning `None` from `glyph_hor_side_bearing`.

This PR only touches `glyph_hor_side_bearing` but I can see similar early `?` handling may affect other similar methods for variable fonts. It may be worth applying similar changes to them, or perhaps it's possible to address the cause of `side_bearing_offset` returning `None` itself instead?

This fix allows all glyphs to return a glyph_hor_side_bearing for #98 so it is, at least, a possible approach.

Resolves #98