### PR TITLE
make fields of lookup subtables public

### DIFF
--- a/src/ggg/lookup.rs
+++ b/src/ggg/lookup.rs
@@ -46,9 +46,12 @@ pub trait LookupSubtable<'a>: Sized {
 /// A list of lookup subtables.
 #[derive(Clone, Copy)]
 pub struct LookupSubtables<'a> {
-    kind: u16,
-    data: &'a [u8],
-    offsets: LazyArray16<'a, Offset16>,
+    /// lookup type for GPOS or GSUB
+    pub kind: u16,
+    /// raw data of subtables
+    pub data: &'a [u8],
+    /// offsets to each lookup subtables
+    pub offsets: LazyArray16<'a, Offset16>,
 }
 
 impl core::fmt::Debug for LookupSubtables<'_> {


### PR DESCRIPTION
A small fix on lookup subtables as the visibility of fields of a public struct are default to private, which means they cannot be accessed from the outside of the module.

```rust
    if let Some(table) = face.tables().gsub {
        for lookup in table.lookups {
            for subtable in lookup.subtables {
                // process subtable
                println!("{}", subtable.kind);
            }
     }
 }
``` 

Use case:
- Some applications may need to manipulate these lookup tables manually so I need access to its fields. (Recently I was developing an text rendering application based on `ttf-parser`'s `LookupSubtables`)

BTW, this project does not have a convention of code style .i.e a `rustfmt` file. So if code style matters, I am willing to revert these unrelated changes (The formatting is performed by `rustfmt` with its default config).
