### PR TITLE
Handle null offsets in MATH table

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -775,19 +775,6 @@ impl<'a> Stream<'a> {
         let offset = self.read::<Offset16>()?.to_usize();
         data.get(offset..)
     }
-
-    #[allow(dead_code)]
-    #[inline]
-    pub(crate) fn parse_at_offset16<T: FromSlice<'a>>(&mut self, data: &'a [u8]) -> Option<T> {
-        self.read_at_offset16(data).and_then(T::parse)
-    }
-
-    #[allow(dead_code)]
-    #[inline]
-    pub(crate) fn read_at_offset32(&mut self, data: &'a [u8]) -> Option<&'a [u8]> {
-        let offset = self.read::<Offset32>()?.to_usize();
-        data.get(offset..)
-    }
 }
 
 /// A common offset methods.

--- a/src/tables/ankr.rs
+++ b/src/tables/ankr.rs
@@ -4,7 +4,7 @@
 use core::num::NonZeroU16;
 
 use crate::aat;
-use crate::parser::{FromData, LazyArray32, Stream};
+use crate::parser::{FromData, LazyArray32, Offset, Offset32, Stream};
 use crate::GlyphId;
 
 /// An anchor point.
@@ -76,5 +76,16 @@ impl<'a> Table<'a> {
         let mut s = Stream::new_at(self.glyphs_data, usize::from(offset))?;
         let number_of_points = s.read::<u32>()?;
         s.read_array32::<Point>(number_of_points)
+    }
+}
+
+trait StreamExt<'a> {
+    fn read_at_offset32(&mut self, data: &'a [u8]) -> Option<&'a [u8]>;
+}
+
+impl<'a> StreamExt<'a> for Stream<'a> {
+    fn read_at_offset32(&mut self, data: &'a [u8]) -> Option<&'a [u8]> {
+        let offset = self.read::<Offset32>()?.to_usize();
+        data.get(offset..)
     }
 }

--- a/src/tables/math.rs
+++ b/src/tables/math.rs
@@ -925,3 +925,14 @@ impl<'a> Table<'a> {
         })
     }
 }
+
+trait StreamExt<'a> {
+    fn parse_at_offset16<T: FromSlice<'a>>(&mut self, data: &'a [u8]) -> Option<T>;
+}
+
+impl<'a> StreamExt<'a> for Stream<'a> {
+    fn parse_at_offset16<T: FromSlice<'a>>(&mut self, data: &'a [u8]) -> Option<T> {
+        let offset = self.read::<Option<Offset16>>()??.to_usize();
+        data.get(offset..).and_then(T::parse)
+    }
+}


### PR DESCRIPTION
This lets math subtables be `None` instead of attempting to read at an offset of `0`. As discussed in #110. It also moves the `read_at_offset32` to a private stream extension for the `ankr` table as discussed. While this doesn't fully resolve the offset problem, it at least fixes the specific bug in the math table.