### PR TITLE
Replace deprecated core::i32::MIN/MAX with standard ones.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.42.0
+          - 1.43.0
           - stable
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Build Status](https://github.com/RazrFalcon/ttf-parser/workflows/Rust/badge.svg)
 [![Crates.io](https://img.shields.io/crates/v/ttf-parser.svg)](https://crates.io/crates/ttf-parser)
 [![Documentation](https://docs.rs/ttf-parser/badge.svg)](https://docs.rs/ttf-parser)
-[![Rust 1.42+](https://img.shields.io/badge/rust-1.42+-orange.svg)](https://www.rust-lang.org)
+[![Rust 1.43+](https://img.shields.io/badge/rust-1.42+-orange.svg)](https://www.rust-lang.org)
 ![](https://img.shields.io/badge/unsafe-forbidden-brightgreen.svg)
 
 A high-level, safe, zero-allocation TrueType font parser.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -224,10 +224,10 @@ impl TryNumFrom<f32> for i32 {
 
         // We can't represent `MIN-1` exactly, but there's no fractional part
         // at this magnitude, so we can just use a `MIN` inclusive boundary.
-        const MIN: f32 = core::i32::MIN as f32;
+        const MIN: f32 = i32::MIN as f32;
         // We can't represent `MAX` exactly, but it will round up to exactly
         // `MAX+1` (a power of two) when we cast it.
-        const MAX_P1: f32 = core::i32::MAX as f32;
+        const MAX_P1: f32 = i32::MAX as f32;
         if v >= MIN && v < MAX_P1 {
             Some(v as i32)
         } else {


### PR DESCRIPTION
`core::i32::MIN` and `core::i32::MAX` have been deprecated, and this commit replaces them with `i32::MIN` and `i32::MAX` respectively.