### PR TITLE
Add missing loca table to FaceTables

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -752,6 +752,7 @@ pub struct FaceTables<'a> {
     pub glyf: Option<glyf::Table<'a>>,
     pub hmtx: Option<hmtx::Table<'a>>,
     pub kern: Option<kern::Table<'a>>,
+    pub loca: Option<loca::Table<'a>>,
     pub name: Option<name::Table<'a>>,
     pub os2: Option<os2::Table<'a>>,
     pub post: Option<post::Table<'a>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1014,6 +1014,7 @@ impl<'a> Face<'a> {
             glyf,
             hmtx,
             kern: raw_tables.kern.and_then(kern::Table::parse),
+            loca,
             name: raw_tables.name.and_then(name::Table::parse),
             os2: raw_tables.os2.and_then(os2::Table::parse),
             post: raw_tables.post.and_then(post::Table::parse),


### PR DESCRIPTION
The `loca` table is missing from `FaceTables` for some reason, this PR adds it.