### PR TITLE
Expose conversion from glyph ID to CID

### DIFF
--- a/src/tables/cff/cff1.rs
+++ b/src/tables/cff/cff1.rs
@@ -1032,6 +1032,17 @@ impl<'a> Table<'a> {
             FontKind::CID(_) => None,
         }
     }
+
+    /// Returns the CID corresponding to a glyph ID.
+    ///
+    /// Returns `None` if this is not a CIDFont.
+    #[cfg(feature = "glyph-names")]
+    pub fn glyph_cid(&self, glyph_id: GlyphId) -> Option<u16> {
+        match self.kind {
+            FontKind::SID(_) => None,
+            FontKind::CID(_) => self.charset.gid_to_sid(glyph_id).map(|id| id.0),
+        }
+    }
 }
 
 impl core::fmt::Debug for Table<'_> {


### PR DESCRIPTION
When embedding a CIDFont in PDF, CIDs must be used in place of GIDs. Most fonts have an identity mapping, but some don't (mostly CJK ones). For those, the mapping is stored as the charset, but SIDs represent CIDs. From the CFF spec:

> The charset data, although in the same format as non-CIDFonts, will represent CIDs rather than SIDs,  [...]

Right now, the GID -> SID functionality in the CFF table is internal to `glyph_name`, which returns a string (which is `None` in this case because there are now actual strings for the "fake" SIDs). It would be great to have an exposed to way to extract the mapping with ttf-parser. I attached one possible way to expose this (open to suggestions for a better API). I opted for specifically calling this `glyph_cid` instead of something like `gid_to_sid` because it makes semantically more sense and also opted to return `None` for non-CID fonts.