### PR TITLE
Add support for COLR/CPAL v0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- `COLR` / `CPAL` v0 parsing.
 
 ## [0.19.2] - 2023-09-13
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ There are roughly three types of TrueType tables:
 | `bloc` table      | ✓                      | ✓                   |                                |
 | `CBDT` table      | ~ (no 8, 9)            | ✓                   |                                |
 | `CBLC` table      | ✓                      | ✓                   |                                |
-| `COLR` table      |                        | ✓                   |                                |
-| `CPAL` table      |                        | ✓                   |                                |
+| `COLR` table      | ~ (only v0)            | ✓                   |                                |
+| `CPAL` table      | ~ (only v0)            | ✓                   |                                |
 | `CFF `&nbsp;table | ✓                      | ✓                   | ~ (no `seac` support)          |
 | `CFF2` table      | ✓                      | ✓                   |                                |
 | `cmap` table      | ~ (no 8)               | ✓                   | ~ (no 2,8,10,14; Unicode-only) |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -824,6 +824,7 @@ pub struct FaceTables<'a> {
     pub cff: Option<cff::Table<'a>>,
     pub cmap: Option<cmap::Table<'a>>,
     pub colr: Option<colr::Table<'a>>,
+    pub cpal: Option<cpal::Table<'a>>,
     pub ebdt: Option<cbdt::Table<'a>>,
     pub glyf: Option<glyf::Table<'a>>,
     pub hmtx: Option<hmtx::Table<'a>>,
@@ -1100,7 +1101,8 @@ impl<'a> Face<'a> {
             None
         };
 
-        let colr = if let Some(cpal) = raw_tables.cpal.and_then(cpal::Table::parse) {
+        let cpal = raw_tables.cpal.and_then(cpal::Table::parse);
+        let colr = if let Some(cpal) = cpal {
             raw_tables
                 .colr
                 .and_then(|data| colr::Table::parse(cpal, data))
@@ -1118,6 +1120,7 @@ impl<'a> Face<'a> {
             cff: raw_tables.cff.and_then(cff::Table::parse),
             cmap: raw_tables.cmap.and_then(cmap::Table::parse),
             colr,
+            cpal,
             ebdt,
             glyf,
             hmtx,

--- a/src/tables/colr.rs
+++ b/src/tables/colr.rs
@@ -90,6 +90,13 @@ impl<'a> Table<'a> {
         })
     }
 
+    /// Whether the table contains a definition for the given glyph.
+    pub fn contains(&self, glyph_id: GlyphId) -> bool {
+        self.base_glyphs
+            .binary_search_by(|base| base.glyph_id.cmp(&glyph_id))
+            .is_some()
+    }
+
     /// Paints the color glyph.
     pub fn paint(
         &self,

--- a/src/tables/colr.rs
+++ b/src/tables/colr.rs
@@ -1,0 +1,115 @@
+//! A [Color Table](
+//! https://docs.microsoft.com/en-us/typography/opentype/spec/colr) implementation.
+
+use crate::cpal::{self, Color};
+use crate::parser::{FromData, LazyArray16, Offset, Offset32, Stream};
+use crate::GlyphId;
+
+/// A [base glyph](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyph-and-layer-records).
+#[derive(Clone, Copy, Debug)]
+struct BaseGlyphRecord {
+    glyph_id: GlyphId,
+    first_layer_index: u16,
+    num_layers: u16,
+}
+
+impl FromData for BaseGlyphRecord {
+    const SIZE: usize = 6;
+
+    fn parse(data: &[u8]) -> Option<Self> {
+        let mut s = Stream::new(data);
+        Some(Self {
+            glyph_id: s.read::<GlyphId>()?,
+            first_layer_index: s.read::<u16>()?,
+            num_layers: s.read::<u16>()?,
+        })
+    }
+}
+
+/// A [layer](https://learn.microsoft.com/en-us/typography/opentype/spec/colr#baseglyph-and-layer-records).
+#[derive(Clone, Copy, Debug)]
+struct LayerRecord {
+    glyph_id: GlyphId,
+    palette_index: u16,
+}
+
+impl FromData for LayerRecord {
+    const SIZE: usize = 4;
+
+    fn parse(data: &[u8]) -> Option<Self> {
+        let mut s = Stream::new(data);
+        Some(Self {
+            glyph_id: s.read::<GlyphId>()?,
+            palette_index: s.read::<u16>()?,
+        })
+    }
+}
+
+/// A trait for color glyph painting.
+pub trait ColorGlyphPainter {
+    /// Paints an outline glyph in the given color.
+    fn glyph(&mut self, id: GlyphId, color: Color);
+}
+
+/// A [Color Table](
+/// https://docs.microsoft.com/en-us/typography/opentype/spec/colr).
+///
+/// Currently, only version 0 is supported.
+#[derive(Clone, Copy, Debug)]
+pub struct Table<'a> {
+    palettes: cpal::Table<'a>,
+    base_glyphs: LazyArray16<'a, BaseGlyphRecord>,
+    layers: LazyArray16<'a, LayerRecord>,
+}
+
+impl<'a> Table<'a> {
+    /// Parses a table from raw data.
+    pub fn parse(palettes: cpal::Table<'a>, data: &'a [u8]) -> Option<Self> {
+        let mut s = Stream::new(data);
+
+        let version = s.read::<u16>()?;
+        if version > 1 {
+            return None;
+        }
+
+        let num_base_glyphs = s.read::<u16>()?;
+        let base_glyphs_offset = s.read::<Offset32>()?;
+        let layers_offset = s.read::<Offset32>()?;
+        let num_layers = s.read::<u16>()?;
+
+        let base_glyphs = Stream::new_at(data, base_glyphs_offset.to_usize())?
+            .read_array16::<BaseGlyphRecord>(num_base_glyphs)?;
+
+        let layers = Stream::new_at(data, layers_offset.to_usize())?
+            .read_array16::<LayerRecord>(num_layers)?;
+
+        Some(Self {
+            palettes,
+            base_glyphs,
+            layers,
+        })
+    }
+
+    /// Paints the color glyph.
+    pub fn paint(
+        &self,
+        glyph_id: GlyphId,
+        palette: u16,
+        painter: &mut dyn ColorGlyphPainter,
+    ) -> Option<()> {
+        let (_, base) = self
+            .base_glyphs
+            .binary_search_by(|base| base.glyph_id.cmp(&glyph_id))?;
+
+        let start = base.first_layer_index;
+        let end = start.checked_add(base.num_layers)?;
+        let layers = self.layers.slice(start..end)?;
+
+        for layer in layers {
+            let color = self.palettes.get(palette, layer.palette_index)?;
+            painter.glyph(layer.glyph_id, color);
+        }
+
+        Some(())
+    }
+}

--- a/src/tables/cpal.rs
+++ b/src/tables/cpal.rs
@@ -1,0 +1,72 @@
+//! A [Color Palette Table](
+//! https://docs.microsoft.com/en-us/typography/opentype/spec/cpal) implementation.
+
+use crate::parser::{FromData, LazyArray16, Offset, Offset32, Stream};
+
+/// A [Color Palette Table](
+/// https://docs.microsoft.com/en-us/typography/opentype/spec/cpal).
+#[derive(Clone, Copy, Debug)]
+pub struct Table<'a> {
+    color_indices: LazyArray16<'a, u16>,
+    colors: LazyArray16<'a, Color>,
+}
+
+impl<'a> Table<'a> {
+    /// Parses a table from raw data.
+    pub fn parse(data: &'a [u8]) -> Option<Self> {
+        let mut s = Stream::new(data);
+
+        let version = s.read::<u16>()?;
+        if version > 1 {
+            return None;
+        }
+
+        s.skip::<u16>(); // number of palette entries
+
+        let num_palettes = s.read::<u16>()?;
+        let num_colors = s.read::<u16>()?;
+        let color_records_offset = s.read::<Offset32>()?;
+        let color_indices = s.read_array16::<u16>(num_palettes)?;
+
+        let colors = Stream::new_at(data, color_records_offset.to_usize())?
+            .read_array16::<Color>(num_colors)?;
+
+        Some(Self {
+            color_indices,
+            colors,
+        })
+    }
+
+    /// Returns the color at the given index into the given palette.
+    pub fn get(&self, palette: u16, palette_entry: u16) -> Option<Color> {
+        let index = self
+            .color_indices
+            .get(palette)?
+            .checked_add(palette_entry)?;
+        self.colors.get(index)
+    }
+}
+
+/// A BGRA color in sRGB.
+#[allow(missing_docs)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Color {
+    pub blue: u8,
+    pub green: u8,
+    pub red: u8,
+    pub alpha: u8,
+}
+
+impl FromData for Color {
+    const SIZE: usize = 4;
+
+    fn parse(data: &[u8]) -> Option<Self> {
+        let mut s = Stream::new(data);
+        Some(Self {
+            blue: s.read::<u8>()?,
+            green: s.read::<u8>()?,
+            red: s.read::<u8>()?,
+            alpha: s.read::<u8>()?,
+        })
+    }
+}

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -2,6 +2,8 @@ pub mod cbdt;
 pub mod cblc;
 mod cff;
 pub mod cmap;
+pub mod colr;
+pub mod cpal;
 pub mod glyf;
 pub mod head;
 pub mod hhea;


### PR DESCRIPTION
This PR adds support for version 0 of the COLR and CPAL tables (#69). Version 0 is very simple in comparison to version 1: A color glyph is defined as a list of overlayed outline glyphs, each with a solid color.

The implementation is also pretty simple, the biggest question is the API design: Since a version 0 color glyph is conceptually really just a list of `(GlyphId, Color)`, an iterator based design would be possible. 

However, such an API design wouldn't accomodate version 1 down the road at all. For this reason, I decided to instead add a `ColorGlyphPainter` trait akin to the `OutlineBuilder` trait (I'm open for alternative naming suggestions). Currently, it only has a single method for painting an outline glyph in a color, but down the road it could be extended to accomodate other COLRv1 features like transformations and gradients. This will likely still be a breaking change (unless the new methods would have empty default impls), but at least the general API shape could remain the same.

I did not add CPAL to `FaceTables` for now, but it could potentially be useful to expose because a color font can have different palettes (e.g. light and dark) and it's up to a text processing application to pick one. CPAL v1 also adds support for named palettes, this especially might make it useful to expose in `FaceTables`.