### PR TITLE
return the svg document include the svg data and the covered range 

### DIFF
--- a/examples/font2svg.rs
+++ b/examples/font2svg.rs
@@ -156,7 +156,7 @@ fn process(args: Args) -> Result<(), Box<dyn std::error::Error>> {
                 buf.extend_from_slice(b"data:image/svg+xml;base64, ");
 
                 let mut enc = base64::write::EncoderWriter::new(buf, base64::STANDARD);
-                enc.write_all(img).unwrap();
+                enc.write_all(img.data).unwrap();
                 enc.finish().unwrap();
             });
             svg.end_element();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2057,7 +2057,7 @@ impl<'a> Face<'a> {
     /// Also, a font can contain both: images and outlines. So when this method returns `None`
     /// you should also try `outline_glyph()` afterwards.
     #[inline]
-    pub fn glyph_svg_image(&self, glyph_id: GlyphId) -> Option<&'a [u8]> {
+    pub fn glyph_svg_image(&self, glyph_id: GlyphId) -> Option<svg::SvgDocument<'a>> {
         self.tables.svg.and_then(|svg| svg.documents.find(glyph_id))
     }
 


### PR DESCRIPTION
A single svg document can be used to represent multiple glyphs, return the covered range with the data.