### PR TITLE
Flip misnamed `is_bitmap_embedding_allowed` function, increase lenience of embed permissions for older OS/2 versions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1709,7 +1709,7 @@ impl<'a> Face<'a> {
         self.tables.os2?.permissions()
     }
 
-    /// Checks if the face subsetting is allowed.
+    /// Checks if the face allows embedding a subset, further restricted by [`Self::permissions`].
     #[inline]
     pub fn is_subsetting_allowed(&self) -> bool {
         self.tables
@@ -1718,12 +1718,15 @@ impl<'a> Face<'a> {
             .unwrap_or(false)
     }
 
-    /// Checks if the face bitmaps embedding is allowed.
+    /// Checks if the face allows outline data to be embedded.
+    /// If false, only bitmaps may be embedded in accordance with [`Self::permissions`].
+    ///
+    /// If the font contains no bitmaps and this flag is not set, it implies no embedding is allowed.
     #[inline]
-    pub fn is_bitmap_embedding_allowed(&self) -> bool {
+    pub fn is_outline_embedding_allowed(&self) -> bool {
         self.tables
             .os2
-            .map(|t| t.is_bitmap_embedding_allowed())
+            .map(|t| t.is_outline_embedding_allowed())
             .unwrap_or(false)
     }
 

--- a/src/tables/os2.rs
+++ b/src/tables/os2.rs
@@ -433,16 +433,19 @@ impl<'a> Table<'a> {
         }
     }
 
-    /// Checks if the face subsetting is allowed.
+    /// Checks if the face allows embedding a subset, further restricted by [`Self::permissions`].
     #[inline]
     pub fn is_subsetting_allowed(&self) -> bool {
         let n = Stream::read_at::<u16>(self.data, TYPE_OFFSET).unwrap_or(0);
         n & 0x0100 == 0
     }
 
-    /// Checks if the face bitmaps embedding is allowed.
+    /// Checks if the face allows outline data to be embedded.
+    /// If false, only bitmaps may be embedded in accordance with [`Self::permissions`].
+    ///
+    /// If the font contains no bitmaps and this flag is not set, it implies no embedding is allowed.
     #[inline]
-    pub fn is_bitmap_embedding_allowed(&self) -> bool {
+    pub fn is_outline_embedding_allowed(&self) -> bool {
         let n = Stream::read_at::<u16>(self.data, TYPE_OFFSET).unwrap_or(0);
         n & 0x0200 == 0
     }

--- a/src/tables/os2.rs
+++ b/src/tables/os2.rs
@@ -424,20 +424,42 @@ impl<'a> Table<'a> {
     #[inline]
     pub fn permissions(&self) -> Option<Permissions> {
         let n = Stream::read_at::<u16>(self.data, TYPE_OFFSET).unwrap_or(0);
-        match n & 0xF {
-            0 => Some(Permissions::Installable),
-            2 => Some(Permissions::Restricted),
-            4 => Some(Permissions::PreviewAndPrint),
-            8 => Some(Permissions::Editable),
-            _ => None,
+        if self.version <= 2 {
+            // Version 2 and prior, applications are allowed to take
+            // the most permissive of provided flags
+            let permission = if n & 0xF == 0 {
+                Permissions::Installable
+            } else if n & 8 != 0 {
+                Permissions::Editable
+            } else if n & 4 != 0 {
+                Permissions::PreviewAndPrint
+            } else {
+                Permissions::Restricted
+            };
+
+            Some(permission)
+        } else {
+            // Version 3 onwards, flags must be mutually exclusive.
+            match n & 0xF {
+                0 => Some(Permissions::Installable),
+                2 => Some(Permissions::Restricted),
+                4 => Some(Permissions::PreviewAndPrint),
+                8 => Some(Permissions::Editable),
+                _ => None,
+            }
         }
     }
 
     /// Checks if the face allows embedding a subset, further restricted by [`Self::permissions`].
     #[inline]
     pub fn is_subsetting_allowed(&self) -> bool {
-        let n = Stream::read_at::<u16>(self.data, TYPE_OFFSET).unwrap_or(0);
-        n & 0x0100 == 0
+        if self.version <= 1 {
+            // Flag introduced in version 2
+            true
+        } else {
+            let n = Stream::read_at::<u16>(self.data, TYPE_OFFSET).unwrap_or(0);
+            n & 0x0100 == 0
+        }
     }
 
     /// Checks if the face allows outline data to be embedded.
@@ -446,8 +468,13 @@ impl<'a> Table<'a> {
     /// If the font contains no bitmaps and this flag is not set, it implies no embedding is allowed.
     #[inline]
     pub fn is_outline_embedding_allowed(&self) -> bool {
-        let n = Stream::read_at::<u16>(self.data, TYPE_OFFSET).unwrap_or(0);
-        n & 0x0200 == 0
+        if self.version <= 1 {
+            // Flag introduced in version 2
+            true
+        } else {
+            let n = Stream::read_at::<u16>(self.data, TYPE_OFFSET).unwrap_or(0);
+            n & 0x0200 == 0
+        }
     }
 
     /// Returns subscript metrics.


### PR DESCRIPTION
After referencing [this Microsoft `fsType` specification](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#fst), I noticed an inconsistency in the functions `{Face, os2::Table}::is_bitmap_embedding_allowed` which seemed to have an inverted interpretation of the flag's meaning. The checked flag, if set, really means "is embed *required* to be bitmap". Since that name isn't very clear either, I inverted the name to `is_outline_embedding_allowed` while keeping the logical return value unflipped.

Further, the specification allows much leniency for earlier versions of the OS/2 table, this PR adjusts the logic of `os2::Table::{permissions, is_subsetting_allowed, is_outline_embedding_allowed}` to take advantage of this to be as lenient as allowable for embeds.

After these changes, I am not sure the default values for when the table isn't found are correct. I assumed that, in a version prior to the flags' introduction, both subsetting and outline embedding are allowed due to the negative naming of the flags (eg. "no subsetting" implies subsetting is the default) but I was unable to find a resource that states this outright.