### PR TITLE
Make `LayoutTable::parse()` public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttf-parser"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Yevhenii Reizner <razrfalcon@gmail.com>"]
 keywords = ["ttf", "truetype", "opentype"]
 categories = ["parser-implementations"]

--- a/src/ggg/layout_table.rs
+++ b/src/ggg/layout_table.rs
@@ -25,7 +25,7 @@ pub struct LayoutTable<'a> {
 }
 
 impl<'a> LayoutTable<'a> {
-    pub(crate) fn parse(data: &'a [u8]) -> Option<Self> {
+    pub fn parse(data: &'a [u8]) -> Option<Self> {
         let mut s = Stream::new(data);
 
         let major_version = s.read::<u16>()?;


### PR DESCRIPTION
 Will be needed for raw gpos/gsub parsing.