### PR TITLE
Add serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["benches/**"]
 [features]
 default = ["std", "opentype-layout", "apple-layout", "variable-fonts", "glyph-names"]
 serde = ["dep:serde"]
-std = []
+std = ["serde?/std"]
 # Enables variable fonts support. Increases binary size almost twice.
 # Includes avar, CFF2, fvar, gvar, HVAR, MVAR and VVAR tables.
 variable-fonts = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["benches/**"]
 
 [features]
 default = ["std", "opentype-layout", "apple-layout", "variable-fonts", "glyph-names"]
+serde = ["dep:serde"]
 std = []
 # Enables variable fonts support. Increases binary size almost twice.
 # Includes avar, CFF2, fvar, gvar, HVAR, MVAR and VVAR tables.
@@ -39,3 +40,6 @@ gvar-alloc = ["std"]
 base64 = "0.13"
 pico-args = "0.5"
 xmlwriter = "0.1"
+
+[dependencies]
+serde = { version = "1.0.196", features = ["derive"], optional = true, default-features = false }

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 #[rustfmt::skip]
 static TABLE: &[(u16, Language, &str, &str)] = &[
     (0x0000, Language::Unknown, "Unknown", "Unknown"),
@@ -216,6 +219,7 @@ static TABLE: &[(u16, Language, &str, &str)] = &[
 #[allow(missing_docs)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Language {
     Unknown = 0,
     Afrikaans_SouthAfrica,

--- a/src/tables/os2.rs
+++ b/src/tables/os2.rs
@@ -4,6 +4,9 @@
 use crate::parser::Stream;
 use crate::LineMetrics;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 const WEIGHT_CLASS_OFFSET: usize = 4;
 const WIDTH_CLASS_OFFSET: usize = 6;
 const TYPE_OFFSET: usize = 8;
@@ -24,6 +27,7 @@ const CAP_HEIGHT_OFFSET: usize = 88;
 /// A face [weight](https://docs.microsoft.com/en-us/typography/opentype/spec/os2#usweightclass).
 #[allow(missing_docs)]
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Weight {
     Thin,
     ExtraLight,
@@ -84,6 +88,7 @@ impl Default for Weight {
 /// A face [width](https://docs.microsoft.com/en-us/typography/opentype/spec/os2#uswidthclass).
 #[allow(missing_docs)]
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Width {
     UltraCondensed,
     ExtraCondensed,
@@ -133,6 +138,7 @@ pub enum Permissions {
 
 /// A face style.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Style {
     /// A face that is neither italic not obliqued.
     Normal,


### PR DESCRIPTION
This PR is actually a group of 3 PRs

- https://github.com/pop-os/cosmic-text/pull/228
- https://github.com/RazrFalcon/fontdb/pull/63
- https://github.com/RazrFalcon/ttf-parser/pull/139

Right now, I'm making a slideshow program which uses `cosmic-text` for shaping and layout. I'd love to be able to serialize my slideshows into a packed serde format, and in order to do that, I need the types in the libraries in these 3 PRs to implement the serde traits. 