### PR TITLE
Fix check in parse_charset

### DIFF
--- a/src/tables/cff/cff1.rs
+++ b/src/tables/cff/cff1.rs
@@ -892,7 +892,7 @@ impl<'a> Table<'a> {
             Some(charset_id::EXPERT_SUBSET) => Charset::ExpertSubset,
             Some(offset) => {
                 let mut s = Stream::new_at(data, offset)?;
-                parse_charset(number_of_glyphs.get(), &mut s)?
+                parse_charset(number_of_glyphs, &mut s)?
             }
             None => Charset::ISOAdobe, // default
         };

--- a/src/tables/cff/charset.rs
+++ b/src/tables/cff/charset.rs
@@ -190,7 +190,7 @@ impl Charset<'_> {
 }
 
 pub(crate) fn parse_charset<'a>(number_of_glyphs: u16, s: &mut Stream<'a>) -> Option<Charset<'a>> {
-    if number_of_glyphs < 2 {
+    if number_of_glyphs < 1 {
         return None;
     }
 

--- a/src/tables/cff/charset.rs
+++ b/src/tables/cff/charset.rs
@@ -1,6 +1,7 @@
 use super::StringId;
 use crate::parser::{FromData, LazyArray16, Stream};
 use crate::GlyphId;
+use std::num::NonZeroU16;
 
 /// The Expert Encoding conversion as defined in the Adobe Technical Note #5176 Appendix C.
 #[rustfmt::skip]
@@ -189,16 +190,15 @@ impl Charset<'_> {
     }
 }
 
-pub(crate) fn parse_charset<'a>(number_of_glyphs: u16, s: &mut Stream<'a>) -> Option<Charset<'a>> {
-    if number_of_glyphs < 1 {
-        return None;
-    }
-
+pub(crate) fn parse_charset<'a>(
+    number_of_glyphs: NonZeroU16,
+    s: &mut Stream<'a>,
+) -> Option<Charset<'a>> {
     // -1 everywhere, since `.notdef` is omitted.
     let format = s.read::<u8>()?;
     match format {
         0 => Some(Charset::Format0(
-            s.read_array16::<StringId>(number_of_glyphs - 1)?,
+            s.read_array16::<StringId>(number_of_glyphs.get() - 1)?,
         )),
         1 => {
             // The number of ranges is not defined, so we have to
@@ -206,7 +206,7 @@ pub(crate) fn parse_charset<'a>(number_of_glyphs: u16, s: &mut Stream<'a>) -> Op
             let mut count = 0;
             {
                 let mut s = s.clone();
-                let mut total_left = number_of_glyphs - 1;
+                let mut total_left = number_of_glyphs.get() - 1;
                 while total_left > 0 {
                     s.skip::<StringId>(); // first
                     let left = s.read::<u8>()?;
@@ -222,7 +222,7 @@ pub(crate) fn parse_charset<'a>(number_of_glyphs: u16, s: &mut Stream<'a>) -> Op
             let mut count = 0;
             {
                 let mut s = s.clone();
-                let mut total_left = number_of_glyphs - 1;
+                let mut total_left = number_of_glyphs.get() - 1;
                 while total_left > 0 {
                     s.skip::<StringId>(); // first
                     let left = s.read::<u16>()?.checked_add(1)?;

--- a/src/tables/cff/charset.rs
+++ b/src/tables/cff/charset.rs
@@ -1,7 +1,7 @@
 use super::StringId;
 use crate::parser::{FromData, LazyArray16, Stream};
 use crate::GlyphId;
-use std::num::NonZeroU16;
+use core::num::NonZeroU16;
 
 /// The Expert Encoding conversion as defined in the Adobe Technical Note #5176 Appendix C.
 #[rustfmt::skip]


### PR DESCRIPTION
So, I'm not entirely sure if this is how it's supposed to be resolved. I was using `ttf-parser` as a fuzzer for my subsetter, and realized that `parse_charset` has this check to return `None` when there is only one glyph (i.e. the .notdef glyph) in the font. This means that it will fail to parse the cff table in that case. However, I would argue that a font with just the .notdef glyph should be perfectly fine in theory (even though in practice this obviously doesn't make a lot of sense), because the `.notdef` glyph can have outlines as well.