### PR TITLE
Fix treating null offsets as error in GSUB

### DIFF
--- a/src/ggg/chained_context.rs
+++ b/src/ggg/chained_context.rs
@@ -45,16 +45,14 @@ impl<'a> ChainedContextLookup<'a> {
             2 => {
                 let coverage = Coverage::parse(s.read_at_offset16(data)?)?;
 
-                let parse_func = || {
-                    match s.read::<Option<Offset16>>()? {
-                        Some(offset) => ClassDefinition::parse(data.get(offset.to_usize()..)?)?,
-                        None => ClassDefinition::Empty,
-                    }
+                let mut parse_func = || match s.read::<Option<Offset16>>()? {
+                    Some(offset) => Some(ClassDefinition::parse(data.get(offset.to_usize()..)?)?),
+                    None => Some(ClassDefinition::Empty),
                 };
 
-                let backtrack_classes = parse_func();
-                let input_classes = parse_func();
-                let lookahead_classes = parse_func();
+                let backtrack_classes = parse_func()?;
+                let input_classes = parse_func()?;
+                let lookahead_classes = parse_func()?;
 
                 let count = s.read::<u16>()?;
                 let offsets = s.read_array16(count)?;

--- a/src/ggg/chained_context.rs
+++ b/src/ggg/chained_context.rs
@@ -44,18 +44,18 @@ impl<'a> ChainedContextLookup<'a> {
             }
             2 => {
                 let coverage = Coverage::parse(s.read_at_offset16(data)?)?;
-                let backtrack_classes = match s.read::<Offset16>()?.to_usize() {
-                    0 => ClassDefinition::Empty,
-                    offset => ClassDefinition::parse(data.get(offset..)?)?,
+
+                let parse_func = || {
+                    match s.read::<Option<Offset16>>()? {
+                        Some(offset) => ClassDefinition::parse(data.get(offset.to_usize()..)?)?,
+                        None => ClassDefinition::Empty,
+                    }
                 };
-                let input_classes = match s.read::<Offset16>()?.to_usize() {
-                    0 => ClassDefinition::Empty,
-                    offset => ClassDefinition::parse(data.get(offset..)?)?,
-                };
-                let lookahead_classes = match s.read::<Offset16>()?.to_usize() {
-                    0 => ClassDefinition::Empty,
-                    offset => ClassDefinition::parse(data.get(offset..)?)?,
-                };
+
+                let backtrack_classes = parse_func();
+                let input_classes = parse_func();
+                let lookahead_classes = parse_func();
+
                 let count = s.read::<u16>()?;
                 let offsets = s.read_array16(count)?;
                 Some(Self::Format2 {

--- a/src/ggg/mod.rs
+++ b/src/ggg/mod.rs
@@ -132,6 +132,7 @@ pub enum ClassDefinition<'a> {
     Format2 {
         records: LazyArray16<'a, RangeRecord>,
     },
+    Empty,
 }
 
 impl<'a> ClassDefinition<'a> {
@@ -162,6 +163,7 @@ impl<'a> ClassDefinition<'a> {
                 .checked_sub(start.0)
                 .and_then(|index| classes.get(index)),
             Self::Format2 { records } => records.range(glyph).map(|record| record.value),
+            Self::Empty => Some(0),
         }
         .unwrap_or(0)
     }


### PR DESCRIPTION
So I was facing problems with a new font added in harfbuzz, and turns out that the reason was that a specific GSUB lookup failed to parse properly. After looking at the spec, I noticed the following:
<img width="883" alt="image" src="https://github.com/RazrFalcon/ttf-parser/assets/47084093/ab713189-2b01-453f-8c00-c743a7dc9a72">

Offsets cann be NULL, which wasn't checked for in our implementation. This is the least invasive approach I could think of (requires no changes in rustybuzz), and the test case passes now as well, so I hope it's okay.