### PR TITLE
Add support for getting phantom points

### DIFF
--- a/src/tables/glyf.rs
+++ b/src/tables/glyf.rs
@@ -599,6 +599,23 @@ impl<'a> Table<'a> {
         outline_impl(self.loca_table, self.data, glyph_data, 0, &mut b)?
     }
 
+    /// Returns the bbox of a glyph.
+    /// Unlike the `outline` method, it does calculate the bbox
+    /// manually by outlining the glyph, but it instead takes the
+    /// bbox that are encoded as part of the glyf program.
+    #[inline]
+    pub(crate) fn bbox(&self, glyph_id: GlyphId) -> Option<Rect> {
+        let glyph_data = self.get(glyph_id)?;
+        let mut s = Stream::new(glyph_data);
+        s.read::<i16>()?; // number of contours
+        Some(Rect {
+            x_min: s.read::<i16>()?,
+            y_min: s.read::<i16>()?,
+            x_max: s.read::<i16>()?,
+            y_max: s.read::<i16>()?,
+        })
+    }
+
     #[inline]
     pub(crate) fn get(&self, glyph_id: GlyphId) -> Option<&'a [u8]> {
         let range = self.loca_table.glyph_range(glyph_id)?;


### PR DESCRIPTION
So, it seems that at least for no variations, the calculated phantom points seem to match the ones from harfbuzz.

However, I'm having somewhat of a hard time figuring out how to best apply the variations to it. What harfbuzz seems to be doing is to just append the points to the glyph points and then process the variations on the vector of glyphs. I tried into looking how we can best implement this, but the big problem seems that the `ttf-parser` implementation works quite differently since we are using iterators, so we cannot just append the phantom points and treat them as regular points. 

And the `parse_variation_data` function from `gvar` requires a bunch of iterators, so I'm not sure what the best way is to call them to just calculate the variations for the phantom points. 

Any help would be appreciated.