### PR TITLE
Wasm-shaper info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,11 @@ glyph-names = []
 # enable this feature.
 gvar-alloc = ["std"]
 
+# Enables experimental features, such as the WASM Shaper experimental feature, 
+# ported from HarfBuzz. https://github.com/harfbuzz/harfbuzz/blob/main/docs/wasm-shaper.md
+experimental = ["wasm-shaper"]
+wasm-shaper = []
+
 [dev-dependencies]
 base64 = "0.22.1"
 pico-args = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub use fvar::VariationAxis;
 pub use language::Language;
 pub use name::{name_id, PlatformId};
 pub use os2::{Permissions, ScriptMetrics, Style, UnicodeRanges, Weight, Width};
-// #[cfg(feature = "wasm-shaper")]
+#[cfg(feature = "wasm-shaper")]
 pub use tables::wasm;
 pub use tables::CFFError;
 #[cfg(feature = "apple-layout")]
@@ -973,7 +973,7 @@ pub struct RawFaceTables<'a> {
     pub mvar: Option<&'a [u8]>,
     #[cfg(feature = "variable-fonts")]
     pub vvar: Option<&'a [u8]>,
-    // #[cfg(feature = "wasm-shaper")]
+    #[cfg(feature = "wasm-shaper")]
     pub wasm: Option<&'a [u8]>,
 }
 
@@ -1045,7 +1045,7 @@ pub struct FaceTables<'a> {
     pub mvar: Option<mvar::Table<'a>>,
     #[cfg(feature = "variable-fonts")]
     pub vvar: Option<vvar::Table<'a>>,
-    // #[cfg(feature = "wasm-shaper")]
+    #[cfg(feature = "wasm-shaper")]
     pub wasm: Option<wasm::Table<'a>>,
 }
 
@@ -1193,8 +1193,8 @@ impl<'a> Face<'a> {
                 b"trak" => tables.trak = table_data,
                 b"vhea" => tables.vhea = table_data,
                 b"vmtx" => tables.vmtx = table_data,
-                // #[cfg(feature = "wasm-shaper")]
-                b"Wasm"  | b"wasm"  /* unsure which it is */  => tables.wasm = table_data,
+                #[cfg(feature = "wasm-shaper")]
+                b"Wasm" => tables.wasm = table_data,
                 _ => {}
             }
         }
@@ -1356,8 +1356,8 @@ impl<'a> Face<'a> {
             mvar: raw_tables.mvar.and_then(mvar::Table::parse),
             #[cfg(feature = "variable-fonts")]
             vvar: raw_tables.vvar.and_then(vvar::Table::parse),
-            // #[cfg(feature = "wasm-shaper")]
-            wasm: raw_tables.wasm.and_then(wasm::Table::parse), // TODO
+            #[cfg(feature = "wasm-shaper")]
+            wasm: raw_tables.wasm.and_then(wasm::Table::parse), 
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,8 @@ pub use fvar::VariationAxis;
 pub use language::Language;
 pub use name::{name_id, PlatformId};
 pub use os2::{Permissions, ScriptMetrics, Style, UnicodeRanges, Weight, Width};
-/* pub */ use tables::wasm;
+// #[cfg(feature = "wasm-shaper")]
+pub use tables::wasm;
 pub use tables::CFFError;
 #[cfg(feature = "apple-layout")]
 pub use tables::{ankr, feat, kerx, morx, trak};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -973,7 +973,7 @@ pub struct RawFaceTables<'a> {
     pub mvar: Option<&'a [u8]>,
     #[cfg(feature = "variable-fonts")]
     pub vvar: Option<&'a [u8]>,
-
+    // #[cfg(feature = "wasm-shaper")]
     pub wasm: Option<&'a [u8]>,
 }
 
@@ -1045,7 +1045,7 @@ pub struct FaceTables<'a> {
     pub mvar: Option<mvar::Table<'a>>,
     #[cfg(feature = "variable-fonts")]
     pub vvar: Option<vvar::Table<'a>>,
-
+    // #[cfg(feature = "wasm-shaper")]
     pub wasm: Option<wasm::Table<'a>>,
 }
 
@@ -1193,6 +1193,8 @@ impl<'a> Face<'a> {
                 b"trak" => tables.trak = table_data,
                 b"vhea" => tables.vhea = table_data,
                 b"vmtx" => tables.vmtx = table_data,
+                // #[cfg(feature = "wasm-shaper")]
+                b"Wasm"  | b"wasm"  /* unsure which it is */  => tables.wasm = table_data,
                 _ => {}
             }
         }
@@ -1354,7 +1356,7 @@ impl<'a> Face<'a> {
             mvar: raw_tables.mvar.and_then(mvar::Table::parse),
             #[cfg(feature = "variable-fonts")]
             vvar: raw_tables.vvar.and_then(vvar::Table::parse),
-
+            // #[cfg(feature = "wasm-shaper")]
             wasm: raw_tables.wasm.and_then(wasm::Table::parse), // TODO
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ pub use fvar::VariationAxis;
 pub use language::Language;
 pub use name::{name_id, PlatformId};
 pub use os2::{Permissions, ScriptMetrics, Style, UnicodeRanges, Weight, Width};
+/* pub */ use tables::wasm;
 pub use tables::CFFError;
 #[cfg(feature = "apple-layout")]
 pub use tables::{ankr, feat, kerx, morx, trak};
@@ -971,6 +972,8 @@ pub struct RawFaceTables<'a> {
     pub mvar: Option<&'a [u8]>,
     #[cfg(feature = "variable-fonts")]
     pub vvar: Option<&'a [u8]>,
+
+    pub wasm: Option<&'a [u8]>,
 }
 
 /// Parsed face tables.
@@ -1041,6 +1044,8 @@ pub struct FaceTables<'a> {
     pub mvar: Option<mvar::Table<'a>>,
     #[cfg(feature = "variable-fonts")]
     pub vvar: Option<vvar::Table<'a>>,
+
+    pub wasm: Option<wasm::Table<'a>>,
 }
 
 /// A font face.
@@ -1348,6 +1353,8 @@ impl<'a> Face<'a> {
             mvar: raw_tables.mvar.and_then(mvar::Table::parse),
             #[cfg(feature = "variable-fonts")]
             vvar: raw_tables.vvar.and_then(vvar::Table::parse),
+
+            wasm: raw_tables.wasm.and_then(wasm::Table::parse), // TODO
         })
     }
 

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -52,7 +52,7 @@ pub mod mvar;
 #[cfg(feature = "variable-fonts")]
 pub mod vvar;
 
-// #[cfg(feature = "wasm-shaper")]
+#[cfg(feature = "wasm-shaper")]
 pub mod wasm;
 
 pub use cff::cff1;

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -52,6 +52,9 @@ pub mod mvar;
 #[cfg(feature = "variable-fonts")]
 pub mod vvar;
 
+// #[cfg(feature = "wasm-shaper")]
+pub mod wasm;
+
 pub use cff::cff1;
 #[cfg(feature = "variable-fonts")]
 pub use cff::cff2;

--- a/src/tables/wasm.rs
+++ b/src/tables/wasm.rs
@@ -1,0 +1,24 @@
+//! A [WASM table](https://github.com/harfbuzz/harfbuzz/blob/main/docs/wasm-shaper.md) experimental implementation
+
+#![allow(unused)] // for the time being
+
+use crate::parser::{Offset as _, Offset32, Stream};
+
+#[derive(Clone, Copy, Debug)]
+pub struct Table<'a> {
+    pub wasm_data: &'a [u8],
+}
+
+impl<'a> Table<'a> {
+    /// Parses a table from raw data.
+    pub fn parse(data: &'a [u8]) -> Option<Self> {
+        // let mut s = Stream::new(data);
+        // s.skip::<u16>(); // version
+        // let doc_list_offset = s.read::<Option<Offset32>>()??;
+
+        // let mut s = Stream::new_at(data, doc_list_offset.to_usize())?;
+        // let count = s.read::<u16>()?;
+
+        Some(Table { wasm_data: data })
+    }
+}

--- a/src/tables/wasm.rs
+++ b/src/tables/wasm.rs
@@ -4,8 +4,10 @@
 
 use crate::parser::{Offset as _, Offset32, Stream};
 
+/// A WASM module. Contains the WASM Raw Data
 #[derive(Clone, Copy, Debug)]
 pub struct Table<'a> {
+    /// Raw WASM data in WASM format.
     pub wasm_data: &'a [u8],
 }
 

--- a/src/tables/wasm.rs
+++ b/src/tables/wasm.rs
@@ -14,13 +14,6 @@ pub struct Table<'a> {
 impl<'a> Table<'a> {
     /// Parses a table from raw data.
     pub fn parse(data: &'a [u8]) -> Option<Self> {
-        // let mut s = Stream::new(data);
-        // s.skip::<u16>(); // version
-        // let doc_list_offset = s.read::<Option<Offset32>>()??;
-
-        // let mut s = Stream::new_at(data, doc_list_offset.to_usize())?;
-        // let count = s.read::<u16>()?;
-
         Some(Table { wasm_data: data })
     }
 }


### PR DESCRIPTION
Initial attempt at reading the Wasm table that's embedded by the `harfbuzz` tool. I tried on one of their example and it seems to load the `wasm` file just fine, tho I have not tried running it yet as it requires functions exports and whatnot and i am still reading about them.

I took the liberty to add a feature flag, tho I am not quite sure if I am doing it right.