### PR TITLE
Use core maths

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,8 @@ jobs:
         toolchain: ${{ matrix.rust }}
         override: true
 
-    - name: Build with no-std-float
-      run: cargo build --no-default-features --features no-std-float
+    - name: Build with no default features
+      run: cargo build --no-default-features
 
     - name: Build with std
       run: cargo build --no-default-features --features std

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       run: cargo build --no-default-features --features std
 
     - name: Build with variable-fonts
-      run: cargo build --no-default-features --features variable-fonts,no-std-float
+      run: cargo build --no-default-features --features variable-fonts
 
     - name: Build with all features
       run: cargo build --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,12 @@ edition = "2018"
 exclude = ["benches/**"]
 
 [dependencies]
-libm = { version = "0.2.8", optional = true }
+core_maths = { version = "0.1.0"}
 
 [features]
 default = ["std", "opentype-layout", "apple-layout", "variable-fonts", "glyph-names"]
-# Enables the use of the standard library. Deactivate this and activate the no-std-float
-# feature to compile for targets that don't have std.
+# Enables the use of the standard library.
 std = []
-no-std-float = ["libm"]
 # Enables variable fonts support. Increases binary size almost twice.
 # Includes avar, CFF2, fvar, gvar, HVAR, MVAR and VVAR tables.
 variable-fonts = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,8 @@ mod tables;
 #[cfg(feature = "variable-fonts")]
 mod var_store;
 
+#[allow(unused_imports)]
+use core_maths::*;
 use head::IndexToLocationFormat;
 pub use parser::{Fixed, FromData, LazyArray16, LazyArray32, LazyArrayIter16, LazyArrayIter32};
 use parser::{NumFrom, Offset, Offset32, Stream, TryNumFrom};
@@ -2411,25 +2413,4 @@ pub fn fonts_in_collection(data: &[u8]) -> Option<u32> {
 
     s.skip::<u32>(); // version
     s.read::<u32>()
-}
-
-#[allow(missing_docs)]
-#[cfg(all(not(feature = "std"), feature = "no-std-float"))]
-pub(crate) trait NoStdFloat {
-    fn sin(self) -> Self;
-    fn cos(self) -> Self;
-    fn tan(self) -> Self;
-}
-
-#[cfg(all(not(feature = "std"), feature = "no-std-float"))]
-impl NoStdFloat for f32 {
-    fn sin(self) -> Self {
-        libm::sinf(self)
-    }
-    fn cos(self) -> Self {
-        libm::cosf(self)
-    }
-    fn tan(self) -> Self {
-        libm::tanf(self)
-    }
 }


### PR DESCRIPTION
So what I did here is that I always include the `core_maths` dependency and I removed `no-std-float`, so that in order to enable `no_std` mode, you can simply disable all default features and don't need to additionally enable a separate feature. The reason for this is that since features are additive, it's apparently [bad practice to have an explicity `no_std` feature.](https://www.reddit.com/r/rust/comments/f2fsi8/comment/fhcji58). Because if one crate depends on `std` of `ttf-parser` and another on `no-std-float`, then both features would be activated if a crates uses both of them as a dependency.

If you want I can undo the last part, though.