### PR TITLE
Add support for the STAT table.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ There are roughly three types of TrueType tables:
 | `OS/2` table      | ✓                      | ✓                   |                                |
 | `post` table      | ✓                      | ✓                   |                                |
 | `sbix` table      | ~ (PNG only)           | ~ (PNG only)        |                                |
+| `STAT` table      | ✓                      |                     |                                |
 | `SVG `&nbsp;table | ✓                      | ✓                   | ✓                              |
 | `trak` table      | ✓                      |                     |                                |
 | `vhea` table      | ✓                      | ✓                   |                                |

--- a/examples/font-info.rs
+++ b/examples/font-info.rs
@@ -1,4 +1,4 @@
-use ttf_parser::stat::AxisValue;
+use ttf_parser::stat::{AxisValue, AxisValueTable};
 
 fn main() {
     let args: Vec<_> = std::env::args().collect();
@@ -101,40 +101,74 @@ fn main() {
         }
 
         println!("  Axis Values:");
-        for value in stat.values() {
-            // println!("    {value:?}");
-            match value {
-                AxisValue::Format1(value) => {
-                    let name = face
+        for table in stat.tables() {
+            match table {
+                AxisValueTable::Format1(table) => {
+                    let value_name = face
                         .names()
                         .into_iter()
-                        .filter(|name| name.name_id == value.value_name_id)
+                        .filter(|name| name.name_id == table.value_name_id)
                         .map(|name| name.to_string().unwrap())
                         .collect::<Vec<_>>()
                         .join(", ");
 
+                    let axis_name = &axis_names[table.axis_index as usize];
+                    let value = table.value;
+                    let flags = table.flags;
+
+                    println!("    {axis_name} {value:?}={value_name:?} flags={flags:?}");
+                }
+                AxisValueTable::Format2(table) => {
+                    let value_name = face
+                        .names()
+                        .into_iter()
+                        .filter(|name| name.name_id == table.value_name_id)
+                        .map(|name| name.to_string().unwrap())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+
+                    let axis_name = &axis_names[table.axis_index as usize];
+                    let nominal_value = table.nominal_value;
+                    let min_value = table.range_min_value;
+                    let max_value = table.range_max_value;
+                    let flags = table.flags;
+
+                    println!("    {axis_name} {min_value:?}..{max_value:?}={value_name:?} nominal={nominal_value:?} flags={flags:?}");
+                }
+                AxisValueTable::Format3(table) => {
+                    let value_name = face
+                        .names()
+                        .into_iter()
+                        .filter(|name| name.name_id == table.value_name_id)
+                        .map(|name| name.to_string().unwrap())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+
+                    let axis_name = &axis_names[table.axis_index as usize];
+                    let value = table.value;
+                    let linked_value = table.linked_value;
+                    let flags = table.flags;
+
                     println!(
-                        "    {}={:?}={name:?} flags={:?}",
-                        &axis_names[value.axis_index as usize], value.value, value.flags
+                        "    {axis_name} {value:?}<=>{linked_value:?} = {value_name:?} flags={flags:?}",
                     );
                 }
-                AxisValue::Format2(_) => todo!(),
-                AxisValue::Format3(value) => {
-                    let name = face
+                AxisValueTable::Format4(table) => {
+                    let value_name = face
                         .names()
                         .into_iter()
-                        .filter(|name| name.name_id == value.value_name_id)
+                        .filter(|name| name.name_id == table.value_name_id)
                         .map(|name| name.to_string().unwrap())
                         .collect::<Vec<_>>()
                         .join(", ");
 
-                    println!(
-                        "    {} {:?}<=>{:?} = {name:?} flags={:?}",
-                        &axis_names[value.axis_index as usize],
-                        value.value,
-                        value.linked_value,
-                        value.flags
-                    );
+                    let flags = table.flags;
+
+                    println!("    {value_name:?} flags={flags:?}");
+                    for pair in table.values {
+                        let AxisValue { axis_index, value } = pair;
+                        println!("      {axis_index} = {value:?}")
+                    }
                 }
             }
         }

--- a/examples/font-info.rs
+++ b/examples/font-info.rs
@@ -1,5 +1,3 @@
-use ttf_parser::stat::{AxisValue, AxisValueSubtable};
-
 fn main() {
     let args: Vec<_> = std::env::args().collect();
     if args.len() != 2 {
@@ -87,91 +85,7 @@ fn main() {
     }
 
     if let Some(stat) = face.tables().stat {
-        let axis_names = stat
-            .axes
-            .into_iter()
-            .map(|axis| axis.tag)
-            .collect::<Vec<_>>();
-
-        println!("Style attributes:");
-
-        println!("  Axes:");
-        for axis in axis_names.iter() {
-            println!("    {}", axis);
-        }
-
-        println!("  Axis Values:");
-        for table in stat.subtables() {
-            match table {
-                AxisValueSubtable::Format1(table) => {
-                    let value_name = face
-                        .names()
-                        .into_iter()
-                        .filter(|name| name.name_id == table.value_name_id)
-                        .map(|name| name.to_string().unwrap())
-                        .collect::<Vec<_>>()
-                        .join(", ");
-
-                    let axis_name = &axis_names[table.axis_index as usize];
-                    let value = table.value;
-                    let flags = table.flags;
-
-                    println!("    {axis_name} {value:?}={value_name:?} flags={flags:?}");
-                }
-                AxisValueSubtable::Format2(table) => {
-                    let value_name = face
-                        .names()
-                        .into_iter()
-                        .filter(|name| name.name_id == table.value_name_id)
-                        .map(|name| name.to_string().unwrap())
-                        .collect::<Vec<_>>()
-                        .join(", ");
-
-                    let axis_name = &axis_names[table.axis_index as usize];
-                    let nominal_value = table.nominal_value;
-                    let min_value = table.range_min_value;
-                    let max_value = table.range_max_value;
-                    let flags = table.flags;
-
-                    println!("    {axis_name} {min_value:?}..{max_value:?}={value_name:?} nominal={nominal_value:?} flags={flags:?}");
-                }
-                AxisValueSubtable::Format3(table) => {
-                    let value_name = face
-                        .names()
-                        .into_iter()
-                        .filter(|name| name.name_id == table.value_name_id)
-                        .map(|name| name.to_string().unwrap())
-                        .collect::<Vec<_>>()
-                        .join(", ");
-
-                    let axis_name = &axis_names[table.axis_index as usize];
-                    let value = table.value;
-                    let linked_value = table.linked_value;
-                    let flags = table.flags;
-
-                    println!(
-                        "    {axis_name} {value:?}<=>{linked_value:?} = {value_name:?} flags={flags:?}",
-                    );
-                }
-                AxisValueSubtable::Format4(table) => {
-                    let value_name = face
-                        .names()
-                        .into_iter()
-                        .filter(|name| name.name_id == table.value_name_id)
-                        .map(|name| name.to_string().unwrap())
-                        .collect::<Vec<_>>()
-                        .join(", ");
-
-                    let flags = table.flags;
-
-                    println!("    {value_name:?} flags={flags:?}");
-                    for pair in table.values {
-                        let AxisValue { axis_index, value } = pair;
-                        println!("      {axis_index} = {value:?}")
-                    }
-                }
-            }
-        }
+        print_opentype_style_attributes(&stat)
     }
 
     println!("Elapsed: {}us", now.elapsed().as_micros());
@@ -199,5 +113,17 @@ fn print_opentype_layout(name: &str, table: &ttf_parser::opentype_layout::Layout
     println!("  Features:");
     for feature in features {
         println!("    {}", feature);
+    }
+}
+
+fn print_opentype_style_attributes(table: &ttf_parser::stat::Table) {
+    println!("Style attributes:");
+
+    println!("  Axes:");
+    for axis in table.axes {
+        println!("    {}", axis.tag);
+        if let Some(subtable) = table.subtable_for_axis(axis.tag, None) {
+            println!("      {subtable:?}")
+        }
     }
 }

--- a/examples/font-info.rs
+++ b/examples/font-info.rs
@@ -1,4 +1,4 @@
-use ttf_parser::stat::{AxisValue, AxisValueTable};
+use ttf_parser::stat::{AxisValue, AxisValueSubtable};
 
 fn main() {
     let args: Vec<_> = std::env::args().collect();
@@ -103,7 +103,7 @@ fn main() {
         println!("  Axis Values:");
         for table in stat.subtables() {
             match table {
-                AxisValueTable::Format1(table) => {
+                AxisValueSubtable::Format1(table) => {
                     let value_name = face
                         .names()
                         .into_iter()
@@ -118,7 +118,7 @@ fn main() {
 
                     println!("    {axis_name} {value:?}={value_name:?} flags={flags:?}");
                 }
-                AxisValueTable::Format2(table) => {
+                AxisValueSubtable::Format2(table) => {
                     let value_name = face
                         .names()
                         .into_iter()
@@ -135,7 +135,7 @@ fn main() {
 
                     println!("    {axis_name} {min_value:?}..{max_value:?}={value_name:?} nominal={nominal_value:?} flags={flags:?}");
                 }
-                AxisValueTable::Format3(table) => {
+                AxisValueSubtable::Format3(table) => {
                     let value_name = face
                         .names()
                         .into_iter()
@@ -153,7 +153,7 @@ fn main() {
                         "    {axis_name} {value:?}<=>{linked_value:?} = {value_name:?} flags={flags:?}",
                     );
                 }
-                AxisValueTable::Format4(table) => {
+                AxisValueSubtable::Format4(table) => {
                     let value_name = face
                         .names()
                         .into_iter()

--- a/examples/font-info.rs
+++ b/examples/font-info.rs
@@ -1,3 +1,5 @@
+use ttf_parser::stat::AxisValue;
+
 fn main() {
     let args: Vec<_> = std::env::args().collect();
     if args.len() != 2 {
@@ -80,6 +82,60 @@ fn main() {
                     "  {} {}..{}, default {}",
                     axis.tag, axis.min_value, axis.max_value, axis.def_value
                 );
+            }
+        }
+    }
+
+    if let Some(stat) = face.tables().stat {
+        let axis_names = stat
+            .axes
+            .into_iter()
+            .map(|axis| axis.tag)
+            .collect::<Vec<_>>();
+
+        println!("Style attributes:");
+
+        println!("  Axes:");
+        for axis in axis_names.iter() {
+            println!("    {}", axis);
+        }
+
+        println!("  Axis Values:");
+        for value in stat.values() {
+            // println!("    {value:?}");
+            match value {
+                AxisValue::Format1(value) => {
+                    let name = face
+                        .names()
+                        .into_iter()
+                        .filter(|name| name.name_id == value.value_name_id)
+                        .map(|name| name.to_string().unwrap())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+
+                    println!(
+                        "    {}={:?}={name:?} flags={:?}",
+                        &axis_names[value.axis_index as usize], value.value, value.flags
+                    );
+                }
+                AxisValue::Format2(_) => todo!(),
+                AxisValue::Format3(value) => {
+                    let name = face
+                        .names()
+                        .into_iter()
+                        .filter(|name| name.name_id == value.value_name_id)
+                        .map(|name| name.to_string().unwrap())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+
+                    println!(
+                        "    {} {:?}<=>{:?} = {name:?} flags={:?}",
+                        &axis_names[value.axis_index as usize],
+                        value.value,
+                        value.linked_value,
+                        value.flags
+                    );
+                }
             }
         }
     }

--- a/examples/font-info.rs
+++ b/examples/font-info.rs
@@ -101,7 +101,7 @@ fn main() {
         }
 
         println!("  Axis Values:");
-        for table in stat.tables() {
+        for table in stat.subtables() {
             match table {
                 AxisValueTable::Format1(table) => {
                     let value_name = face

--- a/examples/font-info.rs
+++ b/examples/font-info.rs
@@ -91,7 +91,7 @@ fn main() {
         for axis in stat.axes {
             println!("    {}", axis.tag);
             if let Some(subtable) = stat.subtable_for_axis(axis.tag, None) {
-                println!("      {subtable:?}")
+                println!("      {:?}", subtable)
             }
         }
     }

--- a/examples/font-info.rs
+++ b/examples/font-info.rs
@@ -85,7 +85,15 @@ fn main() {
     }
 
     if let Some(stat) = face.tables().stat {
-        print_opentype_style_attributes(&stat)
+        println!("Style attributes:");
+
+        println!("  Axes:");
+        for axis in stat.axes {
+            println!("    {}", axis.tag);
+            if let Some(subtable) = stat.subtable_for_axis(axis.tag, None) {
+                println!("      {subtable:?}")
+            }
+        }
     }
 
     println!("Elapsed: {}us", now.elapsed().as_micros());
@@ -113,17 +121,5 @@ fn print_opentype_layout(name: &str, table: &ttf_parser::opentype_layout::Layout
     println!("  Features:");
     for feature in features {
         println!("    {}", feature);
-    }
-}
-
-fn print_opentype_style_attributes(table: &ttf_parser::stat::Table) {
-    println!("Style attributes:");
-
-    println!("  Axes:");
-    for axis in table.axes {
-        println!("    {}", axis.tag);
-        if let Some(subtable) = table.subtable_for_axis(axis.tag, None) {
-            println!("      {subtable:?}")
-        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,8 @@ pub use tables::{ankr, feat, kerx, morx, trak};
 pub use tables::{avar, cff2, fvar, gvar, hvar, mvar, vvar};
 pub use tables::{cbdt, cblc, cff1 as cff, vhea};
 pub use tables::{
-    cmap, colr, cpal, glyf, head, hhea, hmtx, kern, loca, maxp, name, os2, post, sbix, svg, vorg,
+    cmap, colr, cpal, glyf, head, hhea, hmtx, kern, loca, maxp, name, os2, post, sbix, stat, svg,
+    vorg,
 };
 #[cfg(feature = "opentype-layout")]
 pub use tables::{gdef, gpos, gsub, math};
@@ -938,6 +939,7 @@ pub struct RawFaceTables<'a> {
     pub os2: Option<&'a [u8]>,
     pub post: Option<&'a [u8]>,
     pub sbix: Option<&'a [u8]>,
+    pub stat: Option<&'a [u8]>,
     pub svg: Option<&'a [u8]>,
     pub vhea: Option<&'a [u8]>,
     pub vmtx: Option<&'a [u8]>,
@@ -1008,6 +1010,7 @@ pub struct FaceTables<'a> {
     pub os2: Option<os2::Table<'a>>,
     pub post: Option<post::Table<'a>>,
     pub sbix: Option<sbix::Table<'a>>,
+    pub stat: Option<stat::Table<'a>>,
     pub svg: Option<svg::Table<'a>>,
     pub vhea: Option<vhea::Table>,
     pub vmtx: Option<hmtx::Table<'a>>,
@@ -1189,6 +1192,7 @@ impl<'a> Face<'a> {
                 b"name" => tables.name = table_data,
                 b"post" => tables.post = table_data,
                 b"sbix" => tables.sbix = table_data,
+                b"STAT" => tables.stat = table_data,
                 #[cfg(feature = "apple-layout")]
                 b"trak" => tables.trak = table_data,
                 b"vhea" => tables.vhea = table_data,
@@ -1305,6 +1309,7 @@ impl<'a> Face<'a> {
             sbix: raw_tables
                 .sbix
                 .and_then(|data| sbix::Table::parse(maxp.number_of_glyphs, data)),
+            stat: raw_tables.stat.and_then(stat::Table::parse),
             svg: raw_tables.svg.and_then(svg::Table::parse),
             vhea: raw_tables.vhea.and_then(vhea::Table::parse),
             vmtx,

--- a/src/tables/mod.rs
+++ b/src/tables/mod.rs
@@ -15,6 +15,7 @@ pub mod name;
 pub mod os2;
 pub mod post;
 pub mod sbix;
+pub mod stat;
 pub mod svg;
 pub mod vhea;
 pub mod vorg;

--- a/src/tables/stat.rs
+++ b/src/tables/stat.rs
@@ -272,8 +272,7 @@ pub struct Table<'a> {
     pub axes: LazyArray16<'a, AxisRecord>,
     /// Fallback name when everything can be elided.
     pub fallback_name_id: Option<u16>,
-    /// Version of the style attributes table.
-    pub version: u32,
+    version: u32,
     data: &'a [u8],
     value_lookup_start: Offset32,
     value_offsets: LazyArray16<'a, Offset16>,

--- a/src/tables/stat.rs
+++ b/src/tables/stat.rs
@@ -5,7 +5,7 @@ use crate::{
     Fixed, FromData, LazyArray16, Tag,
 };
 
-/// Axis-value pairing.
+/// Axis-value pairing for [`AxisValueSubtableFormat4`].
 #[derive(Clone, Copy, Debug)]
 pub struct AxisValue {
     /// Zero-based index into [`Table::axes`].
@@ -26,7 +26,7 @@ impl FromData for AxisValue {
     }
 }
 
-/// List of axis value subtables.
+/// Iterator over axis value subtables.
 #[derive(Clone, Debug)]
 pub struct AxisValueSubtables<'a> {
     data: Stream<'a>,
@@ -107,7 +107,7 @@ impl FromData for AxisRecord {
     }
 }
 
-/// [Flags](https://learn.microsoft.com/en-us/typography/opentype/spec/stat#flags) for [`AxisValue`].
+/// [Flags](https://learn.microsoft.com/en-us/typography/opentype/spec/stat#flags) for [`AxisValueSubtable`].
 #[derive(Clone, Copy)]
 pub struct AxisValueFlags(u16);
 
@@ -135,12 +135,12 @@ impl core::fmt::Debug for AxisValueFlags {
     }
 }
 
-/// Axis value table format 1
+/// Axis value subtable [format 1](https://learn.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-1).
 #[derive(Clone, Copy, Debug)]
 pub struct AxisValueSubtableFormat1 {
     /// Zero-based index into [`Table::axes`].
     pub axis_index: u16,
-    /// Flags for AxisValue.
+    /// Flags for [`AxisValueSubtable`].
     pub flags: AxisValueFlags,
     /// The name ID of the display string.
     pub value_name_id: u16,
@@ -163,12 +163,12 @@ impl FromData for AxisValueSubtableFormat1 {
     }
 }
 
-/// Axis value table format 2
+/// Axis value subtable [format 2](https://learn.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-2).
 #[derive(Clone, Copy, Debug)]
 pub struct AxisValueSubtableFormat2 {
     /// Zero-based index into [`Table::axes`].
     pub axis_index: u16,
-    /// Flags for AxisValue.
+    /// Flags for [`AxisValueSubtable`].
     pub flags: AxisValueFlags,
     /// The name ID of the display string.
     pub value_name_id: u16,
@@ -197,12 +197,12 @@ impl FromData for AxisValueSubtableFormat2 {
     }
 }
 
-/// Axis value table format 3
+/// Axis value subtable [format 3](https://learn.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-3).
 #[derive(Clone, Copy, Debug)]
 pub struct AxisValueSubtableFormat3 {
     /// Zero-based index into [`Table::axes`].
     pub axis_index: u16,
-    /// Flags for AxisValue.
+    /// Flags for [`AxisValueSubtable`].
     pub flags: AxisValueFlags,
     /// The name ID of the display string.
     pub value_name_id: u16,
@@ -228,10 +228,10 @@ impl FromData for AxisValueSubtableFormat3 {
     }
 }
 
-/// Axis value table format 4
+/// Axis value subtable [format 4](https://learn.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-table-format-4).
 #[derive(Clone, Copy, Debug)]
 pub struct AxisValueSubtableFormat4<'a> {
-    /// Flags for AxisValue.
+    /// Flags for [`AxisValueSubtable`].
     pub flags: AxisValueFlags,
     /// The name ID of the display string.
     pub value_name_id: u16,
@@ -255,7 +255,7 @@ impl<'a> AxisValueSubtableFormat4<'a> {
     }
 }
 
-/// An [axis value table](https://learn.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-tables).
+/// An [axis value subtable](https://learn.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-tables).
 #[allow(missing_docs)]
 #[derive(Clone, Copy, Debug)]
 pub enum AxisValueSubtable<'a> {
@@ -322,7 +322,7 @@ impl<'a> Table<'a> {
         })
     }
 
-    /// Iterator over the collection of axis value tables.
+    /// Returns an iterator over the collection of axis value tables.
     pub fn subtables(&self) -> AxisValueSubtables<'a> {
         AxisValueSubtables {
             data: Stream::new(self.data),
@@ -340,8 +340,8 @@ impl<'a> Table<'a> {
     /// if it is equal to the subtable's value or contained within the range defined by the
     /// subtable. If no matches are found `None` is returned. Typically a match value is not
     /// specified for non-variable fonts as multiple subtables for a given axis ought not exist. For
-    /// variable fonts a non-`None` match value should be specified as multiple records for the
-    /// variation axes exist.
+    /// variable fonts a non-`None` match value should be specified as multiple records for each of
+    /// the variation axes exist.
     ///
     /// Note: Format 4 subtables are explicitly ignored in this function.
     pub fn subtable_for_axis(

--- a/src/tables/stat.rs
+++ b/src/tables/stat.rs
@@ -1,0 +1,314 @@
+//! A [Style Attributes Table](https://docs.microsoft.com/en-us/typography/opentype/spec/stat) implementation.
+
+use crate::{
+    parser::{Offset, Offset16, Offset32, Stream},
+    Fixed, FromData, LazyArray16, Tag,
+};
+
+/// Axis-value pairing.
+#[derive(Clone, Copy, Debug)]
+pub struct AxisValue {
+    /// Zero-based index into [`Table::axes`].
+    pub axis_index: u16,
+    /// Numeric value for this axis.
+    pub value: Fixed,
+}
+
+impl FromData for AxisValue {
+    const SIZE: usize = 6;
+
+    fn parse(data: &[u8]) -> Option<Self> {
+        let mut s = Stream::new(data);
+        let axis_index = s.read::<u16>()?;
+        let value = s.read::<Fixed>()?;
+
+        Some(AxisValue { axis_index, value })
+    }
+}
+
+/// List of axis value tables.
+#[derive(Clone, Debug)]
+pub struct AxisValueTables<'a> {
+    data: Stream<'a>,
+    start: Offset32,
+    offsets: LazyArray16<'a, Offset16>,
+    index: u16,
+}
+
+impl<'a> Iterator for AxisValueTables<'a> {
+    type Item = AxisValueTable<'a>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.offsets.len() {
+            return None;
+        }
+
+        let mut s = Stream::new_at(
+            self.data.tail()?,
+            self.offsets.get(self.index)?.to_usize() + self.start.to_usize(),
+        )?;
+        self.index += 1;
+
+        let format_variant = s.read::<u16>()?;
+
+        let value = match format_variant {
+            1 => {
+                let value = s.read::<AxisValueTableFormat1>()?;
+                Self::Item::Format1(value)
+            }
+            2 => {
+                let value = s.read::<AxisValueTableFormat2>()?;
+                Self::Item::Format2(value)
+            }
+            3 => {
+                let value = s.read::<AxisValueTableFormat3>()?;
+                Self::Item::Format3(value)
+            }
+            4 => {
+                let value = AxisValueTableFormat4::parse(s.tail()?)?;
+                Self::Item::Format4(value)
+            }
+            _ => return None,
+        };
+
+        Some(value)
+    }
+}
+
+/// The [axis record](https://learn.microsoft.com/en-us/typography/opentype/spec/stat#axis-records) struct provides information about a single design axis.
+#[derive(Clone, Copy, Debug)]
+pub struct AxisRecord {
+    /// Axis tag.
+    pub tag: Tag,
+    /// The name ID for entries in the 'name' table that provide a display string for this axis.
+    pub name_id: u16,
+    /// Sort order for e.g. composing font family or face names.
+    pub ordering: u16,
+}
+
+/// [Flags](https://learn.microsoft.com/en-us/typography/opentype/spec/stat#flags) for [`AxisValue`].
+#[derive(Clone, Copy)]
+pub struct AxisValueFlags(u16);
+
+#[rustfmt::skip]
+impl AxisValueFlags {
+    /// If set, this value also applies to older versions of this font.
+    #[inline] pub fn older_sibling_attribute(self) -> bool { self.0 & (1 << 0) != 0 }
+
+    /// If set, this value is the normal (a.k.a. "regular") value for the font family.
+    #[inline] pub fn elidable(self) -> bool { self.0 & (1 << 1) != 0 }
+}
+
+impl core::fmt::Debug for AxisValueFlags {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut dbg = f.debug_set();
+
+        if self.older_sibling_attribute() {
+            dbg.entry(&"OLDER_SIBLING_FONT_ATTRIBUTE");
+        }
+        if self.elidable() {
+            dbg.entry(&"ELIDABLE_AXIS_VALUE_NAME");
+        }
+
+        dbg.finish()
+    }
+}
+
+/// Axis value table format 1
+#[derive(Clone, Copy, Debug)]
+pub struct AxisValueTableFormat1 {
+    /// Zero-based index into [`Table::axes`].
+    pub axis_index: u16,
+    /// Flags for AxisValue.
+    pub flags: AxisValueFlags,
+    /// The name ID of the display string.
+    pub value_name_id: u16,
+    /// Numeric value for this record.
+    pub value: Fixed,
+}
+
+impl FromData for AxisValueTableFormat1 {
+    const SIZE: usize = 10;
+
+    #[inline]
+    fn parse(data: &[u8]) -> Option<Self> {
+        let mut s = Stream::new(data);
+        Some(AxisValueTableFormat1 {
+            axis_index: s.read::<u16>()?,
+            flags: AxisValueFlags(s.read::<u16>()?),
+            value_name_id: s.read::<u16>()?,
+            value: s.read::<Fixed>()?,
+        })
+    }
+}
+
+/// Axis value table format 2
+#[derive(Clone, Copy, Debug)]
+pub struct AxisValueTableFormat2 {
+    /// Zero-based index into [`Table::axes`].
+    pub axis_index: u16,
+    /// Flags for AxisValue.
+    pub flags: AxisValueFlags,
+    /// The name ID of the display string.
+    pub value_name_id: u16,
+    /// Nominal numeric value for this record.
+    pub nominal_value: Fixed,
+    /// The minimum value for this record.
+    pub range_min_value: Fixed,
+    /// The maximum value for this record.
+    pub range_max_value: Fixed,
+}
+
+impl FromData for AxisValueTableFormat2 {
+    const SIZE: usize = 18;
+
+    #[inline]
+    fn parse(data: &[u8]) -> Option<Self> {
+        let mut s = Stream::new(data);
+        Some(AxisValueTableFormat2 {
+            axis_index: s.read::<u16>()?,
+            flags: AxisValueFlags(s.read::<u16>()?),
+            value_name_id: s.read::<u16>()?,
+            nominal_value: s.read::<Fixed>()?,
+            range_min_value: s.read::<Fixed>()?,
+            range_max_value: s.read::<Fixed>()?,
+        })
+    }
+}
+
+/// Axis value table format 3
+#[derive(Clone, Copy, Debug)]
+pub struct AxisValueTableFormat3 {
+    /// Zero-based index into [`Table::axes`].
+    pub axis_index: u16,
+    /// Flags for AxisValue.
+    pub flags: AxisValueFlags,
+    /// The name ID of the display string.
+    pub value_name_id: u16,
+    /// Numeric value for this record.
+    pub value: Fixed,
+    /// Numeric value for a style-linked mapping.
+    pub linked_value: Fixed,
+}
+
+impl FromData for AxisValueTableFormat3 {
+    const SIZE: usize = 14;
+
+    #[inline]
+    fn parse(data: &[u8]) -> Option<Self> {
+        let mut s = Stream::new(data);
+        Some(AxisValueTableFormat3 {
+            axis_index: s.read::<u16>()?,
+            flags: AxisValueFlags(s.read::<u16>()?),
+            value_name_id: s.read::<u16>()?,
+            value: s.read::<Fixed>()?,
+            linked_value: s.read::<Fixed>()?,
+        })
+    }
+}
+
+/// Axis value table format 4
+#[derive(Clone, Copy, Debug)]
+pub struct AxisValueTableFormat4<'a> {
+    /// Flags for AxisValue.
+    pub flags: u16,
+    /// The name ID of the display string.
+    pub value_name_id: u16,
+    /// List of axis-value pairings.
+    pub values: LazyArray16<'a, AxisValue>,
+}
+
+impl<'a> AxisValueTableFormat4<'a> {
+    fn parse(data: &'a [u8]) -> Option<Self> {
+        let mut s = Stream::new(data);
+        let axis_count = s.read::<u16>()?;
+        let flags = s.read::<u16>()?;
+        let value_name_id = s.read::<u16>()?;
+        let values = s.read_array16::<AxisValue>(axis_count)?;
+
+        Some(AxisValueTableFormat4 {
+            flags,
+            value_name_id,
+            values,
+        })
+    }
+}
+
+/// An [axis value table](https://learn.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-tables).
+#[allow(missing_docs)]
+#[derive(Clone, Copy, Debug)]
+pub enum AxisValueTable<'a> {
+    Format1(AxisValueTableFormat1),
+    Format2(AxisValueTableFormat2),
+    Format3(AxisValueTableFormat3),
+    Format4(AxisValueTableFormat4<'a>),
+}
+
+impl FromData for AxisRecord {
+    const SIZE: usize = 8;
+
+    #[inline]
+    fn parse(data: &[u8]) -> Option<Self> {
+        let mut s = Stream::new(data);
+        Some(AxisRecord {
+            tag: s.read::<Tag>()?,
+            name_id: s.read::<u16>()?,
+            ordering: s.read::<u16>()?,
+        })
+    }
+}
+
+/// A [Style Attributes Table](https://docs.microsoft.com/en-us/typography/opentype/spec/stat).
+#[derive(Clone, Copy, Debug)]
+pub struct Table<'a> {
+    /// List of axes
+    pub axes: LazyArray16<'a, AxisRecord>,
+    data: &'a [u8],
+    value_lookup_start: Offset32,
+    value_offsets: LazyArray16<'a, Offset16>,
+}
+
+impl<'a> Table<'a> {
+    /// Parses a table from raw data.
+    pub fn parse(data: &'a [u8]) -> Option<Self> {
+        let mut s = Stream::new(data);
+        let major = s.read::<u16>()?;
+        let minor = s.read::<u16>()?;
+
+        match (major, minor) {
+            (1, 0) | (1, 1) | (1, 2) => {}
+            _ => return None,
+        }
+
+        let _axis_size = s.read::<u16>()?;
+        let axis_count = s.read::<u16>()?;
+        let axis_offset = s.read::<Offset32>()?.to_usize();
+
+        let value_count = s.read::<u16>()?;
+        let value_lookup_start = s.read::<Offset32>()?;
+
+        let mut s = Stream::new_at(data, axis_offset)?;
+        let axes = s.read_array16::<AxisRecord>(axis_count)?;
+
+        let mut s = Stream::new_at(data, value_lookup_start.to_usize())?;
+        let value_offsets = s.read_array16::<Offset16>(value_count)?;
+
+        Some(Self {
+            axes,
+            data,
+            value_lookup_start,
+            value_offsets,
+        })
+    }
+
+    /// Iterator over the collection of axis value tables.
+    pub fn tables(&self) -> AxisValueTables<'a> {
+        AxisValueTables {
+            data: Stream::new(self.data),
+            start: self.value_lookup_start,
+            offsets: self.value_offsets,
+            index: 0,
+        }
+    }
+}

--- a/src/tables/stat.rs
+++ b/src/tables/stat.rs
@@ -324,7 +324,7 @@ impl<'a> Table<'a> {
     }
 
     /// Iterator over the collection of axis value tables.
-    pub fn tables(&self) -> AxisValueTables<'a> {
+    pub fn subtables(&self) -> AxisValueTables<'a> {
         AxisValueTables {
             data: Stream::new(self.data),
             start: self.value_lookup_start,

--- a/src/tables/stat.rs
+++ b/src/tables/stat.rs
@@ -287,7 +287,7 @@ impl<'a> Table<'a> {
         // Supported versions are:
         // - 1.0
         // - 1.1 adds elidedFallbackNameId
-        // - 1.2 format 4 axis value table
+        // - 1.2 adds format 4 axis value table
         if !(version == 0x00010000 || version == 0x00010001 || version == 0x00010002) {
             return None;
         }

--- a/src/tables/stat.rs
+++ b/src/tables/stat.rs
@@ -232,7 +232,7 @@ impl FromData for AxisValueSubtableFormat3 {
 #[derive(Clone, Copy, Debug)]
 pub struct AxisValueSubtableFormat4<'a> {
     /// Flags for AxisValue.
-    pub flags: u16,
+    pub flags: AxisValueFlags,
     /// The name ID of the display string.
     pub value_name_id: u16,
     /// List of axis-value pairings.
@@ -243,7 +243,7 @@ impl<'a> AxisValueSubtableFormat4<'a> {
     fn parse(data: &'a [u8]) -> Option<Self> {
         let mut s = Stream::new(data);
         let axis_count = s.read::<u16>()?;
-        let flags = s.read::<u16>()?;
+        let flags = AxisValueFlags(s.read::<u16>()?);
         let value_name_id = s.read::<u16>()?;
         let values = s.read_array16::<AxisValue>(axis_count)?;
 

--- a/src/tables/stat.rs
+++ b/src/tables/stat.rs
@@ -93,6 +93,20 @@ pub struct AxisRecord {
     pub ordering: u16,
 }
 
+impl FromData for AxisRecord {
+    const SIZE: usize = 8;
+
+    #[inline]
+    fn parse(data: &[u8]) -> Option<Self> {
+        let mut s = Stream::new(data);
+        Some(AxisRecord {
+            tag: s.read::<Tag>()?,
+            name_id: s.read::<u16>()?,
+            ordering: s.read::<u16>()?,
+        })
+    }
+}
+
 /// [Flags](https://learn.microsoft.com/en-us/typography/opentype/spec/stat#flags) for [`AxisValue`].
 #[derive(Clone, Copy)]
 pub struct AxisValueFlags(u16);
@@ -249,20 +263,6 @@ pub enum AxisValueSubtable<'a> {
     Format2(AxisValueSubtableFormat2),
     Format3(AxisValueSubtableFormat3),
     Format4(AxisValueSubtableFormat4<'a>),
-}
-
-impl FromData for AxisRecord {
-    const SIZE: usize = 8;
-
-    #[inline]
-    fn parse(data: &[u8]) -> Option<Self> {
-        let mut s = Stream::new(data);
-        Some(AxisRecord {
-            tag: s.read::<Tag>()?,
-            name_id: s.read::<u16>()?,
-            ordering: s.read::<u16>()?,
-        })
-    }
 }
 
 /// A [Style Attributes Table](https://docs.microsoft.com/en-us/typography/opentype/spec/stat).

--- a/src/tables/stat.rs
+++ b/src/tables/stat.rs
@@ -333,13 +333,17 @@ impl<'a> Table<'a> {
         }
     }
 
-    /// Returns the first matching subtable for a given axis.  If no match value is given the first
-    /// subtable for the axis is returned.  If a match value is given, the first subtable for the
-    /// axis where the value matches is returned.  A value matches if it is equal to the subtable's
-    /// value or contained within the range defined by the subtable.  If no matches are found `None`
-    /// is returned.  Typically a match value is not specified for non-variable fonts as multiple
-    /// subtables for a given axis ought not exist.  For variable fonts a non-`None` match value
-    /// should be specified as multiple records for the variation axes exist.
+    /// Returns the first matching subtable for a given axis.
+    ///
+    /// If no match value is given the first subtable for the axis is returned. If a match value is
+    /// given, the first subtable for the axis where the value matches is returned. A value matches
+    /// if it is equal to the subtable's value or contained within the range defined by the
+    /// subtable. If no matches are found `None` is returned. Typically a match value is not
+    /// specified for non-variable fonts as multiple subtables for a given axis ought not exist. For
+    /// variable fonts a non-`None` match value should be specified as multiple records for the
+    /// variation axes exist.
+    ///
+    /// Note: Format 4 subtables are explicitly ignored in this function.
     pub fn subtable_for_axis(
         &self,
         axis: Tag,

--- a/src/tables/stat.rs
+++ b/src/tables/stat.rs
@@ -37,7 +37,7 @@ pub struct AxisValueSubtables<'a> {
 }
 
 impl<'a> Iterator for AxisValueSubtables<'a> {
-    type Item = AxisValueTable<'a>;
+    type Item = AxisValueSubtable<'a>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -55,15 +55,15 @@ impl<'a> Iterator for AxisValueSubtables<'a> {
 
         let value = match format_variant {
             1 => {
-                let value = s.read::<AxisValueTableFormat1>()?;
+                let value = s.read::<AxisValueSubtableFormat1>()?;
                 Self::Item::Format1(value)
             }
             2 => {
-                let value = s.read::<AxisValueTableFormat2>()?;
+                let value = s.read::<AxisValueSubtableFormat2>()?;
                 Self::Item::Format2(value)
             }
             3 => {
-                let value = s.read::<AxisValueTableFormat3>()?;
+                let value = s.read::<AxisValueSubtableFormat3>()?;
                 Self::Item::Format3(value)
             }
             4 => {
@@ -72,7 +72,7 @@ impl<'a> Iterator for AxisValueSubtables<'a> {
                     return None;
                 }
 
-                let value = AxisValueTableFormat4::parse(s.tail()?)?;
+                let value = AxisValueSubtableFormat4::parse(s.tail()?)?;
                 Self::Item::Format4(value)
             }
             _ => return None,
@@ -123,7 +123,7 @@ impl core::fmt::Debug for AxisValueFlags {
 
 /// Axis value table format 1
 #[derive(Clone, Copy, Debug)]
-pub struct AxisValueTableFormat1 {
+pub struct AxisValueSubtableFormat1 {
     /// Zero-based index into [`Table::axes`].
     pub axis_index: u16,
     /// Flags for AxisValue.
@@ -134,13 +134,13 @@ pub struct AxisValueTableFormat1 {
     pub value: Fixed,
 }
 
-impl FromData for AxisValueTableFormat1 {
+impl FromData for AxisValueSubtableFormat1 {
     const SIZE: usize = 10;
 
     #[inline]
     fn parse(data: &[u8]) -> Option<Self> {
         let mut s = Stream::new(data);
-        Some(AxisValueTableFormat1 {
+        Some(AxisValueSubtableFormat1 {
             axis_index: s.read::<u16>()?,
             flags: AxisValueFlags(s.read::<u16>()?),
             value_name_id: s.read::<u16>()?,
@@ -151,7 +151,7 @@ impl FromData for AxisValueTableFormat1 {
 
 /// Axis value table format 2
 #[derive(Clone, Copy, Debug)]
-pub struct AxisValueTableFormat2 {
+pub struct AxisValueSubtableFormat2 {
     /// Zero-based index into [`Table::axes`].
     pub axis_index: u16,
     /// Flags for AxisValue.
@@ -166,13 +166,13 @@ pub struct AxisValueTableFormat2 {
     pub range_max_value: Fixed,
 }
 
-impl FromData for AxisValueTableFormat2 {
+impl FromData for AxisValueSubtableFormat2 {
     const SIZE: usize = 18;
 
     #[inline]
     fn parse(data: &[u8]) -> Option<Self> {
         let mut s = Stream::new(data);
-        Some(AxisValueTableFormat2 {
+        Some(AxisValueSubtableFormat2 {
             axis_index: s.read::<u16>()?,
             flags: AxisValueFlags(s.read::<u16>()?),
             value_name_id: s.read::<u16>()?,
@@ -185,7 +185,7 @@ impl FromData for AxisValueTableFormat2 {
 
 /// Axis value table format 3
 #[derive(Clone, Copy, Debug)]
-pub struct AxisValueTableFormat3 {
+pub struct AxisValueSubtableFormat3 {
     /// Zero-based index into [`Table::axes`].
     pub axis_index: u16,
     /// Flags for AxisValue.
@@ -198,13 +198,13 @@ pub struct AxisValueTableFormat3 {
     pub linked_value: Fixed,
 }
 
-impl FromData for AxisValueTableFormat3 {
+impl FromData for AxisValueSubtableFormat3 {
     const SIZE: usize = 14;
 
     #[inline]
     fn parse(data: &[u8]) -> Option<Self> {
         let mut s = Stream::new(data);
-        Some(AxisValueTableFormat3 {
+        Some(AxisValueSubtableFormat3 {
             axis_index: s.read::<u16>()?,
             flags: AxisValueFlags(s.read::<u16>()?),
             value_name_id: s.read::<u16>()?,
@@ -216,7 +216,7 @@ impl FromData for AxisValueTableFormat3 {
 
 /// Axis value table format 4
 #[derive(Clone, Copy, Debug)]
-pub struct AxisValueTableFormat4<'a> {
+pub struct AxisValueSubtableFormat4<'a> {
     /// Flags for AxisValue.
     pub flags: u16,
     /// The name ID of the display string.
@@ -225,7 +225,7 @@ pub struct AxisValueTableFormat4<'a> {
     pub values: LazyArray16<'a, AxisValue>,
 }
 
-impl<'a> AxisValueTableFormat4<'a> {
+impl<'a> AxisValueSubtableFormat4<'a> {
     fn parse(data: &'a [u8]) -> Option<Self> {
         let mut s = Stream::new(data);
         let axis_count = s.read::<u16>()?;
@@ -233,7 +233,7 @@ impl<'a> AxisValueTableFormat4<'a> {
         let value_name_id = s.read::<u16>()?;
         let values = s.read_array16::<AxisValue>(axis_count)?;
 
-        Some(AxisValueTableFormat4 {
+        Some(AxisValueSubtableFormat4 {
             flags,
             value_name_id,
             values,
@@ -244,11 +244,11 @@ impl<'a> AxisValueTableFormat4<'a> {
 /// An [axis value table](https://learn.microsoft.com/en-us/typography/opentype/spec/stat#axis-value-tables).
 #[allow(missing_docs)]
 #[derive(Clone, Copy, Debug)]
-pub enum AxisValueTable<'a> {
-    Format1(AxisValueTableFormat1),
-    Format2(AxisValueTableFormat2),
-    Format3(AxisValueTableFormat3),
-    Format4(AxisValueTableFormat4<'a>),
+pub enum AxisValueSubtable<'a> {
+    Format1(AxisValueSubtableFormat1),
+    Format2(AxisValueSubtableFormat2),
+    Format3(AxisValueSubtableFormat3),
+    Format4(AxisValueSubtableFormat4<'a>),
 }
 
 impl FromData for AxisRecord {

--- a/src/tables/stat.rs
+++ b/src/tables/stat.rs
@@ -26,9 +26,9 @@ impl FromData for AxisValue {
     }
 }
 
-/// List of axis value tables.
+/// List of axis value subtables.
 #[derive(Clone, Debug)]
-pub struct AxisValueTables<'a> {
+pub struct AxisValueSubtables<'a> {
     data: Stream<'a>,
     start: Offset32,
     offsets: LazyArray16<'a, Offset16>,
@@ -36,7 +36,7 @@ pub struct AxisValueTables<'a> {
     version: u32,
 }
 
-impl<'a> Iterator for AxisValueTables<'a> {
+impl<'a> Iterator for AxisValueSubtables<'a> {
     type Item = AxisValueTable<'a>;
 
     #[inline]
@@ -324,8 +324,8 @@ impl<'a> Table<'a> {
     }
 
     /// Iterator over the collection of axis value tables.
-    pub fn subtables(&self) -> AxisValueTables<'a> {
-        AxisValueTables {
+    pub fn subtables(&self) -> AxisValueSubtables<'a> {
+        AxisValueSubtables {
             data: Stream::new(self.data),
             start: self.value_lookup_start,
             offsets: self.value_offsets,


### PR DESCRIPTION
https://learn.microsoft.com/en-us/typography/opentype/spec/stat

This PR adds support for parsing the `STAT` table and its related data types.  It's a pretty simple table but as in #87 the issues of testing and API design deserve some consideration.

Additionally, should this be placed behind a feature?