### PR TITLE
Add an accessor for the raw Unicode ranges value on the OS/2 table

### DIFF
--- a/src/tables/os2.rs
+++ b/src/tables/os2.rs
@@ -193,6 +193,11 @@ impl UnicodeRanges {
             false
         }
     }
+
+    /// Returns the raw unicode ranges value
+    pub fn as_raw(&self) -> u128 {
+        self.0
+    }
 }
 
 fn char_range_index(c: char) -> i8 {


### PR DESCRIPTION
Added `UnicodeRanges::as_raw()` to provide access to the underlying raw value for the `ulUnicodeRangeX` fields on the OS/2 table