### PR TITLE
check post italic_angle

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1410,13 +1410,18 @@ impl<'a> Face<'a> {
 
     /// Checks that face is marked as *Italic*.
     ///
-    /// Returns `false` when OS/2 table is not present.
+    /// Returns `false` when OS/2 and post tables are not present.
     #[inline]
     pub fn is_italic(&self) -> bool {
         self.tables
             .os2
             .map(|s| s.style() == Style::Italic)
             .unwrap_or(false)
+            || self
+                .tables
+                .post
+                .map(|s| s.italic_angle <= -1.0)
+                .unwrap_or(false)
     }
 
     /// Checks that face is marked as *Bold*.


### PR DESCRIPTION
I have a font with an italic that under fsSelection says it is not italic. Unsure if bug, or because caslon italic is frequently used for body text? I'm not sure what these tables are. Regular fonts seem to have post angle at 0.0, but I'm not sure if some small angle on body text may be used some time? I've gone with -1.0, total guess. I also tried to pull in some PANOSE italic checking from @inferiorhumanorgans , but think maybe this belongs up near "style(&self)"?  

```
╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Adobe Caslon Pro Italic.ttf: Adobe Caslon Pro (Version 2.093;PS Version 2.000;hotconv 1.0.68;makeotf.lib2.5.35818) │
├──────────────────────┬───────────────────┬─────────────────────────────────────────────────────────┬───────┬───────┤
│                      │ ttf_parser::Face  │                          OS/2                           │ post  │ STAT  │
│                      │                   │ fsSelection  │ PANOSE  │ usWeightClass  │ usWidthClass  │       │       │
├──────────────────────┼───────────────────┼──────────────┼─────────┼────────────────┼───────────────┼───────┼───────┤
│ bold                 │ F                 │ F            │ F       │                │               │       │       │
│ weight               │ Normal            │              │ Book    │ Normal         │               │       │       │
│ italic / oblique     │ F / F             │ F / F        │ T       │                │               │ -22   │       │
│ monospaced           │ F                 │              │ F       │                │               │ F     │       │
│ stretch              │ Normal            │ Normal       │         │                │ Normal        │       │       │
╰──────────────────────┴───────────────────┴──────────────┴─────────┴────────────────┴───────────────┴───────┴───────╯
```