### PR TITLE
Fix: Only apply avar table to the variation axis being set

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2320,16 +2320,17 @@ impl<'a> Face<'a> {
             return None;
         }
 
-        for (i, var_axis) in self.variation_axes().into_iter().enumerate() {
-            if var_axis.tag == axis {
-                self.coordinates.data[i] = var_axis.normalized_value(value);
-            }
-        }
+        if let Some((i, var_axis)) = self
+            .variation_axes()
+            .into_iter()
+            .enumerate()
+            .find(|(_, var_axis)| var_axis.tag == axis)
+        {
+            self.coordinates.data[i] = var_axis.normalized_value(value);
 
-        // TODO: optimize
-        if let Some(avar) = self.tables.avar {
-            // Ignore error.
-            let _ = avar.map_coordinates(self.coordinates.as_mut_slice());
+            if let Some(avar) = self.tables.avar {
+                let _ = avar.map_coordinate(self.coordinates.as_mut_slice(), i);
+            }
         }
 
         Some(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2320,16 +2320,13 @@ impl<'a> Face<'a> {
             return None;
         }
 
-        if let Some((i, var_axis)) = self
-            .variation_axes()
-            .into_iter()
-            .enumerate()
-            .find(|(_, var_axis)| var_axis.tag == axis)
-        {
-            self.coordinates.data[i] = var_axis.normalized_value(value);
+        for (i, var_axis) in self.variation_axes().into_iter().enumerate() {
+            if var_axis.tag == axis {
+                self.coordinates.data[i] = var_axis.normalized_value(value);
 
-            if let Some(avar) = self.tables.avar {
-                let _ = avar.map_coordinate(self.coordinates.as_mut_slice(), i);
+                if let Some(avar) = self.tables.avar {
+                    let _ = avar.map_coordinate(self.coordinates.as_mut_slice(), i);
+                }
             }
         }
 

--- a/src/tables/avar.rs
+++ b/src/tables/avar.rs
@@ -114,13 +114,22 @@ impl<'a> Table<'a> {
         })
     }
 
-    /// Maps coordinates.
-    pub fn map_coordinates(&self, coordinates: &mut [NormalizedCoordinate]) -> Option<()> {
+    /// Maps a singel coordinate
+    pub fn map_coordinate(
+        &self,
+        coordinates: &mut [NormalizedCoordinate],
+        coordinate_index: usize,
+    ) -> Option<()> {
         if usize::from(self.segment_maps.count) != coordinates.len() {
             return None;
         }
 
-        for (map, coord) in self.segment_maps.into_iter().zip(coordinates) {
+        if let Some((map, coord)) = self
+            .segment_maps
+            .into_iter()
+            .zip(coordinates)
+            .nth(coordinate_index)
+        {
             *coord = NormalizedCoordinate::from(map_value(&map, coord.0)?);
         }
 

--- a/src/tables/avar.rs
+++ b/src/tables/avar.rs
@@ -114,7 +114,7 @@ impl<'a> Table<'a> {
         })
     }
 
-    /// Maps a singel coordinate
+    /// Maps a single coordinate
     pub fn map_coordinate(
         &self,
         coordinates: &mut [NormalizedCoordinate],


### PR DESCRIPTION
There is an issue in Rustybuzz where calling `set_variations` which internally calls `set_variation` multiple time will cause the avar table to be applied to the same coordinate value multiple times. This causes the wrong values to be set.

This is an attempt at a fix that by only applying the avar table to the coordinate currently being set.

Fixes RazrFalcon/rustybuzz#136